### PR TITLE
Automate applying SwiftLint autocorrect during Xcode build process

### DIFF
--- a/FightPandemics.xcodeproj/xcshareddata/xcschemes/FightPandemics.xcscheme
+++ b/FightPandemics.xcodeproj/xcshareddata/xcschemes/FightPandemics.xcscheme
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1130"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "swiftlint autocorrect"
+               scriptText = "&quot;$PODS_ROOT/SwiftLint/swiftlint&quot; autocorrect &quot;$SRCROOT&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2F9EFE4C245DFB1700E86700"
+                     BuildableName = "FightPandemics.app"
+                     BlueprintName = "FightPandemics"
+                     ReferencedContainer = "container:FightPandemics.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If this is your first time, please read our contributor guidelines: https://github.com/FightPandemics/FightPandemics-iOS/blob/develop/CONTRIBUTING.md
-->

**What this PR does**:

The command `swiftlint autocorrect` will automatically be applied during the Xcode build process - this should help keep us from doing some mindless formatting corrections

The way this is achieved was by updating our Scheme to include a Build Pre-Action that runs `"$PODS_ROOT/SwiftLint/swiftlint" autocorrect "$SRCROOT"`. To view that, select Scheme > Edit Scheme > uncollapse the Buld section > select Pre-actions

**Which issue(s) this PR fixes**:

Resolves #11 

**Special notes for reviewers**:

To test this out yourself - add some whitespace at the end of any line (this violates the SwiftLint `trailing_whitespace` rule). Then, Build or Run the Xcode project. What you should find is that the trailing whitespace is automatically removed