### PR TITLE
API request utility

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,3 +8,6 @@ line_length:
   error: 350
   ignores_comments: true
   ignores_urls: true
+identifier_name:
+  excluded:
+    - id

--- a/FightPandemics.xcodeproj/project.pbxproj
+++ b/FightPandemics.xcodeproj/project.pbxproj
@@ -7,6 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE462468785200750785 /* HTTPClientError.swift */; };
+		2F72CE4E2468785200750785 /* HTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE472468785200750785 /* HTTPRequestError.swift */; };
+		2F72CE4F2468785200750785 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE482468785200750785 /* HTTPRequest.swift */; };
+		2F72CE502468785200750785 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE492468785200750785 /* JSON.swift */; };
+		2F72CE512468785200750785 /* URLSession+Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE4A2468785200750785 /* URLSession+Networking.swift */; };
+		2F72CE522468785200750785 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE4B2468785200750785 /* HTTPMethod.swift */; };
+		2F72CE532468785200750785 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE4C2468785200750785 /* HTTPClient.swift */; };
+		2F72CE562468789000750785 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE552468789000750785 /* User.swift */; };
+		2F72CE59246878BF00750785 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE58246878BF00750785 /* API.swift */; };
+		2F72CE5B2468790200750785 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE5A2468790200750785 /* APIError.swift */; };
+		2F72CE5D2468793300750785 /* MockAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE5C2468793300750785 /* MockAPI.swift */; };
+		2F72CE5F2468793C00750785 /* FightPandemicsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE5E2468793C00750785 /* FightPandemicsAPI.swift */; };
 		2F9EFE51245DFB1700E86700 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9EFE50245DFB1700E86700 /* AppDelegate.swift */; };
 		2F9EFE53245DFB1700E86700 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9EFE52245DFB1700E86700 /* SceneDelegate.swift */; };
 		2F9EFE58245DFB1700E86700 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2F9EFE56245DFB1700E86700 /* Main.storyboard */; };
@@ -41,6 +53,18 @@
 /* Begin PBXFileReference section */
 		1B2D26DC438B7D306CA2A965 /* Pods_FightPandemics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FightPandemics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E355787FFC962848DBBB507 /* Pods-FightPandemics.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FightPandemics.release.xcconfig"; path = "Target Support Files/Pods-FightPandemics/Pods-FightPandemics.release.xcconfig"; sourceTree = "<group>"; };
+		2F72CE462468785200750785 /* HTTPClientError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClientError.swift; sourceTree = "<group>"; };
+		2F72CE472468785200750785 /* HTTPRequestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequestError.swift; sourceTree = "<group>"; };
+		2F72CE482468785200750785 /* HTTPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
+		2F72CE492468785200750785 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		2F72CE4A2468785200750785 /* URLSession+Networking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLSession+Networking.swift"; sourceTree = "<group>"; };
+		2F72CE4B2468785200750785 /* HTTPMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		2F72CE4C2468785200750785 /* HTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
+		2F72CE552468789000750785 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		2F72CE58246878BF00750785 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		2F72CE5A2468790200750785 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		2F72CE5C2468793300750785 /* MockAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPI.swift; sourceTree = "<group>"; };
+		2F72CE5E2468793C00750785 /* FightPandemicsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FightPandemicsAPI.swift; sourceTree = "<group>"; };
 		2F9EFE4D245DFB1700E86700 /* FightPandemics.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FightPandemics.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F9EFE50245DFB1700E86700 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2F9EFE52245DFB1700E86700 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -93,6 +117,40 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		2F72CE452468785200750785 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				2F72CE4C2468785200750785 /* HTTPClient.swift */,
+				2F72CE462468785200750785 /* HTTPClientError.swift */,
+				2F72CE4B2468785200750785 /* HTTPMethod.swift */,
+				2F72CE492468785200750785 /* JSON.swift */,
+				2F72CE4A2468785200750785 /* URLSession+Networking.swift */,
+				2F72CE482468785200750785 /* HTTPRequest.swift */,
+				2F72CE472468785200750785 /* HTTPRequestError.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		2F72CE542468788400750785 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				2F72CE57246878B900750785 /* API */,
+				2F72CE552468789000750785 /* User.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		2F72CE57246878B900750785 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				2F72CE58246878BF00750785 /* API.swift */,
+				2F72CE5A2468790200750785 /* APIError.swift */,
+				2F72CE5E2468793C00750785 /* FightPandemicsAPI.swift */,
+				2F72CE5C2468793300750785 /* MockAPI.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
 		2F9EFE44245DFB1700E86700 = {
 			isa = PBXGroup;
 			children = (
@@ -117,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				2F9EFE71245DFC9F00E86700 /* UIComponets */,
+				2F72CE542468788400750785 /* Models */,
 				2F9EFE68245DFC9F00E86700 /* Utilities */,
 				2F9EFE50245DFB1700E86700 /* AppDelegate.swift */,
 				2F9EFE64245DFC9000E86700 /* Home.swift */,
@@ -133,6 +192,7 @@
 		2F9EFE68245DFC9F00E86700 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				2F72CE452468785200750785 /* Networking */,
 				2F9EFE6C245DFC9F00E86700 /* AccessibilityIdentifier.swift */,
 				2F9EFE6A245DFC9F00E86700 /* UIColorExtension.swift */,
 				2F9EFE88245DFD7400E86700 /* UIResponderExtension.swift */,
@@ -321,16 +381,28 @@
 				2F9EFE84245DFC9F00E86700 /* MenuItem.swift in Sources */,
 				2F9EFE83245DFC9F00E86700 /* Header.swift in Sources */,
 				2F9EFE7D245DFC9F00E86700 /* UIViewExtension.swift in Sources */,
+				2F72CE502468785200750785 /* JSON.swift in Sources */,
 				2F9EFE85245DFC9F00E86700 /* LargeText.swift in Sources */,
+				2F72CE5B2468790200750785 /* APIError.swift in Sources */,
+				2F72CE4E2468785200750785 /* HTTPRequestError.swift in Sources */,
 				2F9EFE67245DFC9700E86700 /* BaseViewController.swift in Sources */,
 				2F9EFE7A245DFC9F00E86700 /* UIColorExtension.swift in Sources */,
+				2F72CE522468785200750785 /* HTTPMethod.swift in Sources */,
 				2F9EFE7C245DFC9F00E86700 /* AccessibilityIdentifier.swift in Sources */,
+				2F72CE562468789000750785 /* User.swift in Sources */,
+				2F72CE512468785200750785 /* URLSession+Networking.swift in Sources */,
 				2F9EFE81245DFC9F00E86700 /* MainText.swift in Sources */,
 				2F9EFE89245DFD7400E86700 /* UIResponderExtension.swift in Sources */,
 				2F9EFE86245DFC9F00E86700 /* Menu.swift in Sources */,
+				2F72CE59246878BF00750785 /* API.swift in Sources */,
 				2F9EFE51245DFB1700E86700 /* AppDelegate.swift in Sources */,
+				2F72CE5F2468793C00750785 /* FightPandemicsAPI.swift in Sources */,
 				2F9EFE65245DFC9000E86700 /* Home.swift in Sources */,
+				2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */,
+				2F72CE532468785200750785 /* HTTPClient.swift in Sources */,
+				2F72CE4F2468785200750785 /* HTTPRequest.swift in Sources */,
 				2F9EFE53245DFB1700E86700 /* SceneDelegate.swift in Sources */,
+				2F72CE5D2468793300750785 /* MockAPI.swift in Sources */,
 				2F9EFE87245DFC9F00E86700 /* Button.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FightPandemics/Home.swift
+++ b/FightPandemics/Home.swift
@@ -27,6 +27,9 @@
 import UIKit
 
 class ViewController: BaseViewController {
+
+    var api: API! = MockAPI()
+
     var news1: Button!
     var news2: Button!
     var news3: Button!
@@ -46,6 +49,16 @@ class ViewController: BaseViewController {
         view.addGestureRecognizer(panGesture)
 
         drawScreen()
+
+        // Demo API usage
+        api.getUser(byID: "123") { result in
+            switch result {
+            case .success(let user):
+                print("Hello, \(user.firstName)!")
+            case .failure(let error):
+                print("ERROR: \(error.localizedDescription)")
+            }
+        }
     }
     func drawScreen() {
 

--- a/FightPandemics/Models/API/API.swift
+++ b/FightPandemics/Models/API/API.swift
@@ -1,0 +1,33 @@
+//
+//  API.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/10/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+protocol API {
+
+    func getUser(byID userID: String, completion: @escaping (Result<User, APIError>) -> Void)
+
+}

--- a/FightPandemics/Models/API/APIError.swift
+++ b/FightPandemics/Models/API/APIError.swift
@@ -1,0 +1,42 @@
+//
+//  APIError.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/10/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+enum APIError: Error, LocalizedError {
+    case httpClientError(value: HTTPClientError)
+    case unimplemented(endpoint: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .httpClientError(let error):
+            return error.localizedDescription
+        case .unimplemented(let endpoint):
+            return "API endpoint not yet implemented: \(endpoint)"
+        }
+    }
+
+}

--- a/FightPandemics/Models/API/FightPandemicsAPI.swift
+++ b/FightPandemics/Models/API/FightPandemicsAPI.swift
@@ -1,0 +1,52 @@
+//
+//  FightPandemicsAPI.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/10/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+final class FightPandemicsAPI: API {
+
+    // MARK: - Properties
+
+    let baseURL: String
+    let httpClient: HTTPClient
+
+    // MARK: - Init/Deinit
+
+    init( baseURL: String, httpClient: HTTPClient) {
+        self.baseURL = baseURL
+        self.httpClient = httpClient
+    }
+
+    // MARK: - Protocol conformance
+
+    // MARK: FightPandemicsAPI
+
+    func getUser(byID userID: String, completion: @escaping (Result<User, APIError>) -> Void) {
+        assertionFailure("API not implemented yet")
+        completion(.failure(.unimplemented(endpoint: "/users/:userId")))
+    }
+
+}

--- a/FightPandemics/Models/API/MockAPI.swift
+++ b/FightPandemics/Models/API/MockAPI.swift
@@ -1,0 +1,36 @@
+//
+//  MockAPI.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/10/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+final class MockAPI: API {
+
+    func getUser(byID userID: String, completion: @escaping (Result<User, APIError>) -> Void) {
+        let mockUser = User(id: "123", firstName: "Jane", lastName: "Domuch", email: "jane@do.co")
+        completion(.success(mockUser))
+    }
+
+}

--- a/FightPandemics/Models/User.swift
+++ b/FightPandemics/Models/User.swift
@@ -1,0 +1,34 @@
+//
+//  User.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/10/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+struct User: Decodable {
+    let id: String
+    let firstName: String
+    let lastName: String
+    let email: String
+}

--- a/FightPandemics/Utilities/Networking/HTTPClient.swift
+++ b/FightPandemics/Utilities/Networking/HTTPClient.swift
@@ -1,0 +1,109 @@
+//
+//  HTTPClient.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/7/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// HTTP client returning JSON that utilizes a URL session.
+class HTTPClient {
+
+    // MARK: - Properties
+
+    /// URL session used for requests.
+    let urlSession: URLSession
+
+    /// Decoder used to parse JSON in responses.
+    let decoder: JSONDecoder
+
+    /// Options used when converting Data to JSON.
+    let options: JSONSerialization.ReadingOptions
+
+    // MARK: - Initializers
+
+    init(urlSession: URLSession = URLSession.shared,
+         decoder: JSONDecoder = JSONDecoder(),
+         options: JSONSerialization.ReadingOptions = []) {
+        self.urlSession = urlSession
+        self.decoder = decoder
+        self.options = options
+    }
+
+    // MARK: - Instance methods
+
+    func sendModelRequest<T: Decodable>(url: URL,
+                                        httpMethod: HTTPMethod,
+                                        modelType: T.Type,
+                                        completion: @escaping (Result<T, HTTPClientError>) -> Void) {
+        var httpRequest = HTTPRequest(url: url)
+        httpRequest.httpMethod = httpMethod.rawValue
+        sendModelRequest(httpRequest, modelType: modelType, completion: completion)
+    }
+
+    func sendModelRequest<T: Decodable>(_ httpRequest: HTTPRequest,
+                                        modelType: T.Type,
+                                        completion: @escaping (Result<T, HTTPClientError>) -> Void) {
+        sendJSONRequest(httpRequest) { [weak self] result in
+            guard let `self` = self else { return }
+
+            switch result {
+            case .success(let response):
+                do {
+                    let model = try self.decoder.decode(modelType.self, from: response.data)
+                    completion(.success(model))
+                } catch {
+                    completion(.failure(.jsonParsingFailed))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func sendJSONRequest(_ httpRequest: HTTPRequest,
+                         completion: @escaping (Result<(data: Data, json: JSON), HTTPClientError>) -> Void) {
+        urlSession.httpRequest(httpRequest) { [weak self] result in
+            guard let `self` = self else { return }
+
+            switch result {
+            case .success(let data):
+                do {
+                    let json = try JSONSerialization.jsonObject(with: data, options: self.options)
+
+                    guard JSONSerialization.isValidJSONObject(json) else {
+                        completion(.failure(.invalidJSON(value: json)))
+                        return
+                    }
+
+                    completion(.success((data, json)))
+                } catch {
+                    completion(.failure(.invalidJSON(value: data)))
+                }
+            case .failure(let error):
+                completion(.failure(.httpRequestError(error: error)))
+            }
+        }
+    }
+
+}

--- a/FightPandemics/Utilities/Networking/HTTPClientError.swift
+++ b/FightPandemics/Utilities/Networking/HTTPClientError.swift
@@ -1,0 +1,50 @@
+//
+//  HTTPClientError.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/7/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// Errors when transforming HTTP request reponse to model from JSON.
+///
+/// - invalidJSON: Data not in valid JSON format.
+/// - jsonParsingFailed: JSON could not be parsed into expected model.
+/// - httpRequestError: Error from HTTP request.
+enum HTTPClientError: Error, LocalizedError {
+    case invalidJSON(value: Any)
+    case jsonParsingFailed
+    case httpRequestError(error: HTTPRequestError)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidJSON:
+            return "Invalid JSON"
+        case .jsonParsingFailed:
+            return "JSON Parsing failed"
+        case .httpRequestError(let error):
+            return error.localizedDescription
+        }
+    }
+
+}

--- a/FightPandemics/Utilities/Networking/HTTPMethod.swift
+++ b/FightPandemics/Utilities/Networking/HTTPMethod.swift
@@ -1,0 +1,35 @@
+//
+//  HTTPMethod.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/7/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// HTTP method.
+ enum HTTPMethod: String {
+    case GET
+    case POST
+    case PUT
+    case DELETE
+}

--- a/FightPandemics/Utilities/Networking/HTTPRequest.swift
+++ b/FightPandemics/Utilities/Networking/HTTPRequest.swift
@@ -1,0 +1,30 @@
+//
+//  HTTPRequest.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/7/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// A URL load request to be used in context that expects an HTTP response.
+typealias HTTPRequest = URLRequest

--- a/FightPandemics/Utilities/Networking/HTTPRequestError.swift
+++ b/FightPandemics/Utilities/Networking/HTTPRequestError.swift
@@ -1,0 +1,51 @@
+//
+//  HTTPRequestError.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/7/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// Errors when making an HTTP request.
+///
+/// - responseError: HTTP request returned with an error.
+/// - incompleteResponse: HTTP request returned without error but with incomplete info.
+/// - errorStatusCode: HTTP request returned without error but with error status code.
+enum HTTPRequestError: Error, LocalizedError {
+    case responseError(error: Error)
+    case incompleteResponse(data: Data?, response: HTTPURLResponse?)
+    case errorStatusCode(value: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .responseError(let error):
+            return error.localizedDescription
+        case .incompleteResponse(_, let response):
+            let urlResponseString = response == nil ? "nil" : response!.description
+            return "Incomplete response: \(urlResponseString)"
+        case .errorStatusCode(let statusCode):
+            return "Error Status Code: \(statusCode)"
+        }
+    }
+
+}

--- a/FightPandemics/Utilities/Networking/JSON.swift
+++ b/FightPandemics/Utilities/Networking/JSON.swift
@@ -1,0 +1,30 @@
+//
+//  JSON.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/7/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// JSON.
+typealias JSON = Any

--- a/FightPandemics/Utilities/Networking/URLSession+Networking.swift
+++ b/FightPandemics/Utilities/Networking/URLSession+Networking.swift
@@ -1,0 +1,57 @@
+//
+//  URLSession+Networking.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/7/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+extension URLSession {
+
+    func httpRequest(_ httpRequest: HTTPRequest,
+                     completion: @escaping (Result<Data, HTTPRequestError>) -> Void) {
+            _ = dataTask(with: httpRequest, completionHandler: { (data, response, error) in
+                if let error = error {
+                    completion(.failure(.responseError(error: error)))
+                    return
+                }
+
+                guard
+                    let unwrappedData = data,
+                    let httpResponse = response as? HTTPURLResponse else {
+                        completion(.failure(.incompleteResponse(data: data, response: response as? HTTPURLResponse)))
+                        return
+                }
+
+                let successStatusCodes: Range<Int> = 200..<300
+
+                guard successStatusCodes.contains(httpResponse.statusCode) else {
+                    completion(.failure(.errorStatusCode(value: httpResponse.statusCode)))
+                    return
+                }
+
+                completion(.success(unwrappedData))
+            }).resume()
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If this is your first time, please read our contributor guidelines: https://github.com/FightPandemics/FightPandemics-iOS/blob/develop/CONTRIBUTING.md
-->

**What this PR does**:

This PR introduces a generic utility for making HTTP request (`HTTPClient`). This utility does assume a few things:

Assumptions
* requests are `HTTP` requests
* the response format is `JSON`
* the API uses `REST` architecture

A couple other structural suggestions are implied: JSON parsing is handled via `Codable`; data models conform to `Decodable` accordingly; data requests use the `Result` type to model their response

An abstraction called `DataRepository` was made to sit in front of all data requests - whether from the API or from persistent storage on the device. A utility named `MockDataRepository` is also supplied to help us work against mock data in the event the API is not available

**Which issue(s) this PR fixes**:

Resolves #14
