### PR TITLE
Mock API requests utility

### DIFF
--- a/FightPandemics.xcodeproj/project.pbxproj
+++ b/FightPandemics.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		2F72CE5B2468790200750785 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE5A2468790200750785 /* APIError.swift */; };
 		2F72CE5D2468793300750785 /* MockAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE5C2468793300750785 /* MockAPI.swift */; };
 		2F72CE5F2468793C00750785 /* FightPandemicsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE5E2468793C00750785 /* FightPandemicsAPI.swift */; };
+		2F72CE6224687C7100750785 /* JSONFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE6124687C7100750785 /* JSONFileReader.swift */; };
+		2F72CE6424687C9A00750785 /* JSONFileReaderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE6324687C9A00750785 /* JSONFileReaderError.swift */; };
+		2F72CE6724687CD100750785 /* User.json in Resources */ = {isa = PBXBuildFile; fileRef = 2F72CE6624687CD100750785 /* User.json */; };
 		2F9EFE51245DFB1700E86700 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9EFE50245DFB1700E86700 /* AppDelegate.swift */; };
 		2F9EFE53245DFB1700E86700 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9EFE52245DFB1700E86700 /* SceneDelegate.swift */; };
 		2F9EFE58245DFB1700E86700 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2F9EFE56245DFB1700E86700 /* Main.storyboard */; };
@@ -65,6 +68,9 @@
 		2F72CE5A2468790200750785 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		2F72CE5C2468793300750785 /* MockAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPI.swift; sourceTree = "<group>"; };
 		2F72CE5E2468793C00750785 /* FightPandemicsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FightPandemicsAPI.swift; sourceTree = "<group>"; };
+		2F72CE6124687C7100750785 /* JSONFileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONFileReader.swift; sourceTree = "<group>"; };
+		2F72CE6324687C9A00750785 /* JSONFileReaderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONFileReaderError.swift; sourceTree = "<group>"; };
+		2F72CE6624687CD100750785 /* User.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = User.json; sourceTree = "<group>"; };
 		2F9EFE4D245DFB1700E86700 /* FightPandemics.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FightPandemics.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F9EFE50245DFB1700E86700 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2F9EFE52245DFB1700E86700 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -143,12 +149,30 @@
 		2F72CE57246878B900750785 /* API */ = {
 			isa = PBXGroup;
 			children = (
+				2F72CE6524687CC500750785 /* Mocks */,
 				2F72CE58246878BF00750785 /* API.swift */,
 				2F72CE5A2468790200750785 /* APIError.swift */,
 				2F72CE5E2468793C00750785 /* FightPandemicsAPI.swift */,
 				2F72CE5C2468793300750785 /* MockAPI.swift */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		2F72CE6024687C6700750785 /* File Reader */ = {
+			isa = PBXGroup;
+			children = (
+				2F72CE6124687C7100750785 /* JSONFileReader.swift */,
+				2F72CE6324687C9A00750785 /* JSONFileReaderError.swift */,
+			);
+			path = "File Reader";
+			sourceTree = "<group>";
+		};
+		2F72CE6524687CC500750785 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				2F72CE6624687CD100750785 /* User.json */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		2F9EFE44245DFB1700E86700 = {
@@ -192,6 +216,7 @@
 		2F9EFE68245DFC9F00E86700 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				2F72CE6024687C6700750785 /* File Reader */,
 				2F72CE452468785200750785 /* Networking */,
 				2F9EFE6C245DFC9F00E86700 /* AccessibilityIdentifier.swift */,
 				2F9EFE6A245DFC9F00E86700 /* UIColorExtension.swift */,
@@ -315,6 +340,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2F72CE6724687CD100750785 /* User.json in Resources */,
 				2F9EFE5D245DFB1900E86700 /* LaunchScreen.storyboard in Resources */,
 				2F9EFE5A245DFB1900E86700 /* Assets.xcassets in Resources */,
 				2F9EFE58245DFB1700E86700 /* Main.storyboard in Resources */,
@@ -383,6 +409,7 @@
 				2F9EFE7D245DFC9F00E86700 /* UIViewExtension.swift in Sources */,
 				2F72CE502468785200750785 /* JSON.swift in Sources */,
 				2F9EFE85245DFC9F00E86700 /* LargeText.swift in Sources */,
+				2F72CE6224687C7100750785 /* JSONFileReader.swift in Sources */,
 				2F72CE5B2468790200750785 /* APIError.swift in Sources */,
 				2F72CE4E2468785200750785 /* HTTPRequestError.swift in Sources */,
 				2F9EFE67245DFC9700E86700 /* BaseViewController.swift in Sources */,
@@ -400,6 +427,7 @@
 				2F9EFE65245DFC9000E86700 /* Home.swift in Sources */,
 				2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */,
 				2F72CE532468785200750785 /* HTTPClient.swift in Sources */,
+				2F72CE6424687C9A00750785 /* JSONFileReaderError.swift in Sources */,
 				2F72CE4F2468785200750785 /* HTTPRequest.swift in Sources */,
 				2F9EFE53245DFB1700E86700 /* SceneDelegate.swift in Sources */,
 				2F72CE5D2468793300750785 /* MockAPI.swift in Sources */,

--- a/FightPandemics/Models/API/Mocks/User.json
+++ b/FightPandemics/Models/API/Mocks/User.json
@@ -1,0 +1,6 @@
+{
+    "id": "123",
+    "firstName": "Jane",
+    "lastName": "Domuch",
+    "email": "jane@do.co"
+}

--- a/FightPandemics/Utilities/File Reader/JSONFileReader.swift
+++ b/FightPandemics/Utilities/File Reader/JSONFileReader.swift
@@ -1,0 +1,65 @@
+//
+//  JSONFileReader.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/9/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// Reads files containing JSON.
+final class JSONFileReader {
+
+    // MARK: - Properties
+
+    let decoder: JSONDecoder
+    let options: JSONSerialization.ReadingOptions
+
+    // MARK: - Init/Deinit
+
+    init(decoder: JSONDecoder = JSONDecoder(),
+         options: JSONSerialization.ReadingOptions = []) {
+        self.decoder = decoder
+        self.options = options
+    }
+
+    // MARK: - Instance methods
+
+    /// Reads and parses the provided JSON file into a model.
+    /// - Parameter fileName: JSON file name.
+    /// - Parameter modelType: Type of model created from JSON.
+    func read<T: Decodable>(fileNamed fileName: String,
+                            modelType: T.Type) -> Result<T, JSONFileReaderError> {
+        guard let filePath = Bundle.main.path(forResource: fileName, ofType: "json") else {
+            return .failure(.fileNotFound(fileName: "\(fileName).json"))
+        }
+
+        do {
+            let data = try Data(contentsOf: URL(fileURLWithPath: filePath))
+            let model = try decoder.decode(modelType.self, from: data)
+            return .success(model)
+        } catch {
+            return .failure(.error(value: error))
+        }
+    }
+
+}

--- a/FightPandemics/Utilities/File Reader/JSONFileReaderError.swift
+++ b/FightPandemics/Utilities/File Reader/JSONFileReaderError.swift
@@ -1,8 +1,8 @@
 //
-//  MockAPI.swift
+//  JSONFileReaderError.swift
 //  FightPandemics
 //
-//  Created by Harlan Kellaway on 5/10/20.
+//  Created by Harlan Kellaway on 5/9/20.
 //
 //  Copyright (c) 2020 FightPandemics
 //
@@ -26,33 +26,19 @@
 
 import Foundation
 
-final class MockAPI: API {
+enum JSONFileReaderError: Error, LocalizedError {
+    case fileNotFound(fileName: String)
+    case invalidJSON(value: Any)
+    case error(value: Error)
 
-    let jsonFileReader: JSONFileReader
-    let latency: DispatchTimeInterval
-
-    init(jsonFileReader: JSONFileReader = JSONFileReader(),
-         latency: DispatchTimeInterval = .seconds(3)) {
-        self.jsonFileReader = jsonFileReader
-        self.latency = latency
-    }
-
-    func getUser(byID userID: String,
-                 completion: @escaping (Result<User, APIError>) -> Void) {
-        let user = jsonFileReader.read(fileNamed: "User", modelType: User.self)
-        simulateNetworkDelay(then: {
-            switch user {
-            case .success(let user):
-                completion(.success(user))
-            case .failure:
-                completion(.failure(.httpClientError(value: .jsonParsingFailed)))
-            }
-        })
-    }
-
-    private func simulateNetworkDelay(then: @escaping () -> Void) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + latency) {
-            then()
+    var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let fileName):
+            return "File not found: \(fileName)"
+        case .invalidJSON(let value):
+            return "Invalid JSON: \(value)"
+        case .error(let error):
+            return error.localizedDescription
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If this is your first time, please read our contributor guidelines: https://github.com/FightPandemics/FightPandemics-iOS/blob/develop/CONTRIBUTING.md
-->

**What this PR does**:

This PR adds a utility that will help us mock API responses. 

The idea is we'll create `.json` files will the expected JSON response format, and setup `MockDataRepository` to return those.

You can see an example in this PR with the `User.json` file (which does follow current specs for the `User` model) and `MockDataRepository` returns the contents of that file after simulating a network delay.

**Which issue(s) this PR fixes**:

Resolves #23