### PR TITLE
Log In wireframe

### DIFF
--- a/FightPandemics.xcodeproj/project.pbxproj
+++ b/FightPandemics.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		2F042194246CD022005FB1D0 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F042193246CD022005FB1D0 /* SearchViewController.swift */; };
 		2F042197246CE4A7005FB1D0 /* Auth.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2F042196246CE4A7005FB1D0 /* Auth.storyboard */; };
 		2F042199246CE4B3005FB1D0 /* LogInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F042198246CE4B3005FB1D0 /* LogInViewController.swift */; };
+		2F04219C246CE921005FB1D0 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F04219B246CE921005FB1D0 /* SessionManager.swift */; };
+		2F04219E246CE99C005FB1D0 /* Success.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F04219D246CE99C005FB1D0 /* Success.swift */; };
+		2F0421A0246CEAB5005FB1D0 /* SessionManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F04219F246CEAB5005FB1D0 /* SessionManagerError.swift */; };
 		2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE462468785200750785 /* HTTPClientError.swift */; };
 		2F72CE4E2468785200750785 /* HTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE472468785200750785 /* HTTPRequestError.swift */; };
 		2F72CE4F2468785200750785 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE482468785200750785 /* HTTPRequest.swift */; };
@@ -91,6 +94,9 @@
 		2F042193246CD022005FB1D0 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		2F042196246CE4A7005FB1D0 /* Auth.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Auth.storyboard; sourceTree = "<group>"; };
 		2F042198246CE4B3005FB1D0 /* LogInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogInViewController.swift; sourceTree = "<group>"; };
+		2F04219B246CE921005FB1D0 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
+		2F04219D246CE99C005FB1D0 /* Success.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Success.swift; sourceTree = "<group>"; };
+		2F04219F246CEAB5005FB1D0 /* SessionManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerError.swift; sourceTree = "<group>"; };
 		2F72CE462468785200750785 /* HTTPClientError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClientError.swift; sourceTree = "<group>"; };
 		2F72CE472468785200750785 /* HTTPRequestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequestError.swift; sourceTree = "<group>"; };
 		2F72CE482468785200750785 /* HTTPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
@@ -207,6 +213,15 @@
 			path = Auth;
 			sourceTree = "<group>";
 		};
+		2F04219A246CE914005FB1D0 /* Session Manager */ = {
+			isa = PBXGroup;
+			children = (
+				2F04219B246CE921005FB1D0 /* SessionManager.swift */,
+				2F04219F246CEAB5005FB1D0 /* SessionManagerError.swift */,
+			);
+			path = "Session Manager";
+			sourceTree = "<group>";
+		};
 		2F72CE452468785200750785 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
@@ -226,6 +241,7 @@
 			children = (
 				2F72CE57246878B900750785 /* API */,
 				2F72CE552468789000750785 /* User.swift */,
+				2F04219D246CE99C005FB1D0 /* Success.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -301,6 +317,7 @@
 				2F72CE6024687C6700750785 /* File Reader */,
 				2FB342022468FFC3007E397F /* Navigation */,
 				2F72CE452468785200750785 /* Networking */,
+				2F04219A246CE914005FB1D0 /* Session Manager */,
 				2FB341E72468F838007E397F /* Style Guide */,
 			);
 			path = Utilities;
@@ -557,6 +574,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F72CE502468785200750785 /* JSON.swift in Sources */,
+				2F04219E246CE99C005FB1D0 /* Success.swift in Sources */,
 				2FB341F92468F9F0007E397F /* RootTabBarController.swift in Sources */,
 				2F72CE6224687C7100750785 /* JSONFileReader.swift in Sources */,
 				2F72CE5B2468790200750785 /* APIError.swift in Sources */,
@@ -569,6 +587,7 @@
 				2FB341EC2468F841007E397F /* UIColor+FightPandemics.swift in Sources */,
 				2F72CE562468789000750785 /* User.swift in Sources */,
 				2F72CE512468785200750785 /* URLSession+Networking.swift in Sources */,
+				2F0421A0246CEAB5005FB1D0 /* SessionManagerError.swift in Sources */,
 				2FB341E92468F838007E397F /* Fonts.swift in Sources */,
 				2F72CE59246878BF00750785 /* API.swift in Sources */,
 				2F9EFE51245DFB1700E86700 /* AppDelegate.swift in Sources */,
@@ -576,6 +595,7 @@
 				2F04210F246A1021005FB1D0 /* AvatarView.swift in Sources */,
 				2FB342042468FFCC007E397F /* Navigator.swift in Sources */,
 				2F042190246CCD4A005FB1D0 /* ProfileViewController.swift in Sources */,
+				2F04219C246CE921005FB1D0 /* SessionManager.swift in Sources */,
 				2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */,
 				2F72CE532468785200750785 /* HTTPClient.swift in Sources */,
 				2F72CE6424687C9A00750785 /* JSONFileReaderError.swift in Sources */,

--- a/FightPandemics.xcodeproj/project.pbxproj
+++ b/FightPandemics.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		2F042190246CCD4A005FB1D0 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F04218F246CCD4A005FB1D0 /* ProfileViewController.swift */; };
 		2F042192246CD017005FB1D0 /* Search.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2F042191246CD017005FB1D0 /* Search.storyboard */; };
 		2F042194246CD022005FB1D0 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F042193246CD022005FB1D0 /* SearchViewController.swift */; };
+		2F042197246CE4A7005FB1D0 /* Auth.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2F042196246CE4A7005FB1D0 /* Auth.storyboard */; };
+		2F042199246CE4B3005FB1D0 /* LogInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F042198246CE4B3005FB1D0 /* LogInViewController.swift */; };
 		2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE462468785200750785 /* HTTPClientError.swift */; };
 		2F72CE4E2468785200750785 /* HTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE472468785200750785 /* HTTPRequestError.swift */; };
 		2F72CE4F2468785200750785 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE482468785200750785 /* HTTPRequest.swift */; };
@@ -87,6 +89,8 @@
 		2F04218F246CCD4A005FB1D0 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		2F042191246CD017005FB1D0 /* Search.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Search.storyboard; sourceTree = "<group>"; };
 		2F042193246CD022005FB1D0 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		2F042196246CE4A7005FB1D0 /* Auth.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Auth.storyboard; sourceTree = "<group>"; };
+		2F042198246CE4B3005FB1D0 /* LogInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogInViewController.swift; sourceTree = "<group>"; };
 		2F72CE462468785200750785 /* HTTPClientError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClientError.swift; sourceTree = "<group>"; };
 		2F72CE472468785200750785 /* HTTPRequestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequestError.swift; sourceTree = "<group>"; };
 		2F72CE482468785200750785 /* HTTPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
@@ -192,6 +196,15 @@
 				2F04218F246CCD4A005FB1D0 /* ProfileViewController.swift */,
 			);
 			path = Profile;
+			sourceTree = "<group>";
+		};
+		2F042195246CE49E005FB1D0 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				2F042196246CE4A7005FB1D0 /* Auth.storyboard */,
+				2F042198246CE4B3005FB1D0 /* LogInViewController.swift */,
+			);
+			path = Auth;
 			sourceTree = "<group>";
 		};
 		2F72CE452468785200750785 /* Networking */ = {
@@ -313,6 +326,7 @@
 		2FB341ED2468F8BA007E397F /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				2F042195246CE49E005FB1D0 /* Auth */,
 				2F0420F5246A0D0D005FB1D0 /* Feed */,
 				2F04218C246CCD36005FB1D0 /* Profile */,
 				2F04218B246CCD36005FB1D0 /* Search */,
@@ -470,6 +484,7 @@
 				2F04212D246A25CF005FB1D0 /* Localizable.strings in Resources */,
 				2F72CE6724687CD100750785 /* User.json in Resources */,
 				2F0420F7246A0E71005FB1D0 /* Feed.storyboard in Resources */,
+				2F042197246CE4A7005FB1D0 /* Auth.storyboard in Resources */,
 				DDDB55082468AE5A008EA75A /* DMSans-Regular.ttf in Resources */,
 				DDDB550A2468AEA7008EA75A /* Poppins-Regular.otf in Resources */,
 				2FB341F62468F984007E397F /* Main.storyboard in Resources */,
@@ -549,6 +564,7 @@
 				2F04218A246CCBFA005FB1D0 /* FeedViewController.swift in Sources */,
 				2F04210D246A1021005FB1D0 /* Avatar.swift in Sources */,
 				2F72CE522468785200750785 /* HTTPMethod.swift in Sources */,
+				2F042199246CE4B3005FB1D0 /* LogInViewController.swift in Sources */,
 				2F04210E246A1021005FB1D0 /* FeedPost.swift in Sources */,
 				2FB341EC2468F841007E397F /* UIColor+FightPandemics.swift in Sources */,
 				2F72CE562468789000750785 /* User.swift in Sources */,

--- a/FightPandemics.xcodeproj/project.pbxproj
+++ b/FightPandemics.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		2F04219C246CE921005FB1D0 /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F04219B246CE921005FB1D0 /* SessionManager.swift */; };
 		2F04219E246CE99C005FB1D0 /* Success.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F04219D246CE99C005FB1D0 /* Success.swift */; };
 		2F0421A0246CEAB5005FB1D0 /* SessionManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F04219F246CEAB5005FB1D0 /* SessionManagerError.swift */; };
+		2F0421A2246CF27B005FB1D0 /* AuthCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0421A1246CF27B005FB1D0 /* AuthCredentials.swift */; };
+		2F0421A4246D04B9005FB1D0 /* AutoLogInFakeLaunchScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0421A3246D04B9005FB1D0 /* AutoLogInFakeLaunchScreen.swift */; };
+		2F0421A6246D0D39005FB1D0 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0421A5246D0D39005FB1D0 /* Environment.swift */; };
 		2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE462468785200750785 /* HTTPClientError.swift */; };
 		2F72CE4E2468785200750785 /* HTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE472468785200750785 /* HTTPRequestError.swift */; };
 		2F72CE4F2468785200750785 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE482468785200750785 /* HTTPRequest.swift */; };
@@ -97,6 +100,9 @@
 		2F04219B246CE921005FB1D0 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		2F04219D246CE99C005FB1D0 /* Success.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Success.swift; sourceTree = "<group>"; };
 		2F04219F246CEAB5005FB1D0 /* SessionManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerError.swift; sourceTree = "<group>"; };
+		2F0421A1246CF27B005FB1D0 /* AuthCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthCredentials.swift; sourceTree = "<group>"; };
+		2F0421A3246D04B9005FB1D0 /* AutoLogInFakeLaunchScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLogInFakeLaunchScreen.swift; sourceTree = "<group>"; };
+		2F0421A5246D0D39005FB1D0 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		2F72CE462468785200750785 /* HTTPClientError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClientError.swift; sourceTree = "<group>"; };
 		2F72CE472468785200750785 /* HTTPRequestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequestError.swift; sourceTree = "<group>"; };
 		2F72CE482468785200750785 /* HTTPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
@@ -209,6 +215,7 @@
 			children = (
 				2F042196246CE4A7005FB1D0 /* Auth.storyboard */,
 				2F042198246CE4B3005FB1D0 /* LogInViewController.swift */,
+				2F0421A3246D04B9005FB1D0 /* AutoLogInFakeLaunchScreen.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -240,8 +247,9 @@
 			isa = PBXGroup;
 			children = (
 				2F72CE57246878B900750785 /* API */,
-				2F72CE552468789000750785 /* User.swift */,
+				2F0421A1246CF27B005FB1D0 /* AuthCredentials.swift */,
 				2F04219D246CE99C005FB1D0 /* Success.swift */,
+				2F72CE552468789000750785 /* User.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -251,6 +259,7 @@
 			children = (
 				2F72CE6524687CC500750785 /* Mocks */,
 				2F72CE58246878BF00750785 /* API.swift */,
+				2F0421A5246D0D39005FB1D0 /* Environment.swift */,
 				2F72CE5E2468793C00750785 /* FightPandemicsAPI.swift */,
 				2F72CE5C2468793300750785 /* MockAPI.swift */,
 				2F72CE5A2468790200750785 /* APIError.swift */,
@@ -586,7 +595,9 @@
 				2F04210E246A1021005FB1D0 /* FeedPost.swift in Sources */,
 				2FB341EC2468F841007E397F /* UIColor+FightPandemics.swift in Sources */,
 				2F72CE562468789000750785 /* User.swift in Sources */,
+				2F0421A6246D0D39005FB1D0 /* Environment.swift in Sources */,
 				2F72CE512468785200750785 /* URLSession+Networking.swift in Sources */,
+				2F0421A2246CF27B005FB1D0 /* AuthCredentials.swift in Sources */,
 				2F0421A0246CEAB5005FB1D0 /* SessionManagerError.swift in Sources */,
 				2FB341E92468F838007E397F /* Fonts.swift in Sources */,
 				2F72CE59246878BF00750785 /* API.swift in Sources */,
@@ -596,6 +607,7 @@
 				2FB342042468FFCC007E397F /* Navigator.swift in Sources */,
 				2F042190246CCD4A005FB1D0 /* ProfileViewController.swift in Sources */,
 				2F04219C246CE921005FB1D0 /* SessionManager.swift in Sources */,
+				2F0421A4246D04B9005FB1D0 /* AutoLogInFakeLaunchScreen.swift in Sources */,
 				2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */,
 				2F72CE532468785200750785 /* HTTPClient.swift in Sources */,
 				2F72CE6424687C9A00750785 /* JSONFileReaderError.swift in Sources */,

--- a/FightPandemics/Base.lproj/LaunchScreen.storyboard
+++ b/FightPandemics/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,9 +12,19 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="vfA-HM-XtA">
+                                <rect key="frame" x="197" y="443" width="20" height="20"/>
+                                <color key="color" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </activityIndicatorView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="vfA-HM-XtA" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="gZe-1I-UOk"/>
+                            <constraint firstItem="vfA-HM-XtA" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="nwq-Tr-wUZ"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                 </viewController>

--- a/FightPandemics/Features/Auth/Auth.storyboard
+++ b/FightPandemics/Features/Auth/Auth.storyboard
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gi0-ee-im4">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Log In View Controller-->
+        <scene sceneID="NAy-H6-4yP">
+            <objects>
+                <viewController storyboardIdentifier="LogInViewController" id="k7R-8i-0gC" customClass="LogInViewController" customModule="FightPandemics" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="SJF-lb-dVI">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="ebV-ag-dkh"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="z4W-vO-bIf"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Vwz-aX-Jfg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1047.8260869565217" y="137.94642857142856"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="A3E-Ka-7RN">
+            <objects>
+                <navigationController storyboardIdentifier="LogInNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="gi0-ee-im4" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="RFJ-N7-sh2">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="30V-Xr-kIx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="137.68115942028987" y="137.94642857142856"/>
+        </scene>
+    </scenes>
+</document>

--- a/FightPandemics/Features/Auth/AutoLogInFakeLaunchScreen.swift
+++ b/FightPandemics/Features/Auth/AutoLogInFakeLaunchScreen.swift
@@ -1,0 +1,74 @@
+//
+//  AutoLogInFakeLaunchScreen.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/14/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+
+/// View that fakes the appearance of the Launch Screen in order to perform Auto-Login.
+final class AutoLoginFakeLaunchScreen {
+
+    private let rootWindow: UIWindow?
+    private let containerView = UIView()
+    private let loadingSpinner = UIActivityIndicatorView(style: .medium)
+
+    init(rootWindow: UIWindow?) {
+        self.rootWindow = rootWindow
+    }
+
+    func show() {
+        guard let rootView = rootWindow?.rootViewController?.view else {
+            return
+        }
+
+        // TODO: UI should match Launch screen https://github.com/FightPandemics/FightPandemics-iOS/issues/52
+        containerView.backgroundColor = .white
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        rootView.addSubview(containerView)
+        NSLayoutConstraint.activate([
+            containerView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
+            containerView.topAnchor.constraint(equalTo: rootView.topAnchor),
+            containerView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor)
+        ])
+
+        loadingSpinner.color = .darkGray
+        loadingSpinner.startAnimating()
+        loadingSpinner.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(loadingSpinner)
+        NSLayoutConstraint.activate([
+            loadingSpinner.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            loadingSpinner.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
+        ])
+    }
+
+    func dismiss() {
+        UIView.animate(withDuration: 1.0, animations: { [weak self] in
+            self?.containerView.alpha = 0.0
+        }, completion: { [weak self] _ in
+            self?.containerView.removeFromSuperview()
+        })
+    }
+
+}

--- a/FightPandemics/Features/Auth/LogInViewController.swift
+++ b/FightPandemics/Features/Auth/LogInViewController.swift
@@ -28,8 +28,33 @@ import UIKit
 
 final class LogInViewController: UIViewController {
 
-    deinit {
-        print("here")
+    // MARK: - Properties
+
+    var navigator: Navigator!
+
+    // MARK: - Overrides
+
+    // MARK: View life-cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupUI()
+    }
+
+    // MARK: - Instance methods
+
+    // MARK: Private instance methods
+
+    private func setupUI() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "LogInCTA".localized,
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(logIn))
+    }
+
+    @objc private func logIn() {
+        navigator.dismissLogIn()
     }
 
 }

--- a/FightPandemics/Features/Auth/LogInViewController.swift
+++ b/FightPandemics/Features/Auth/LogInViewController.swift
@@ -51,6 +51,8 @@ final class LogInViewController: UIViewController {
                                                             style: .plain,
                                                             target: self,
                                                             action: #selector(logIn))
+        title = "Tap Log In >>>"
+        view.backgroundColor = .systemTeal
     }
 
     @objc private func logIn() {

--- a/FightPandemics/Features/Auth/LogInViewController.swift
+++ b/FightPandemics/Features/Auth/LogInViewController.swift
@@ -31,6 +31,9 @@ final class LogInViewController: UIViewController {
     // MARK: - Properties
 
     var navigator: Navigator!
+    var sessionManager: SessionManager!
+
+    private var loadingSpinner = UIActivityIndicatorView()
 
     // MARK: - Overrides
 
@@ -53,10 +56,39 @@ final class LogInViewController: UIViewController {
                                                             action: #selector(logIn))
         title = "Tap Log In >>>"
         view.backgroundColor = .systemTeal
+
+        loadingSpinner.translatesAutoresizingMaskIntoConstraints = false
+        loadingSpinner.color = .white
+        view.addSubview(loadingSpinner)
+        NSLayoutConstraint.activate([
+            loadingSpinner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loadingSpinner.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
     }
 
     @objc private func logIn() {
-        navigator.dismissLogIn()
+        loadingSpinner.startAnimating()
+        disableForm()
+        sessionManager.logIn(email: "lily@luke.co", password: "Pass123") { [weak self] result in
+            self?.loadingSpinner.stopAnimating()
+            self?.enableForm()
+
+            switch result {
+            case .success:
+                self?.navigator.dismissLogIn()
+            case .failure(let error):
+                // TODO: Error handling
+                print(error)
+            }
+        }
+    }
+
+    private func enableForm() {
+         navigationItem.rightBarButtonItem?.isEnabled = true
+    }
+
+    private func disableForm() {
+        navigationItem.rightBarButtonItem?.isEnabled = false
     }
 
 }

--- a/FightPandemics/Features/Auth/LogInViewController.swift
+++ b/FightPandemics/Features/Auth/LogInViewController.swift
@@ -1,0 +1,35 @@
+//
+//  LogInViewController.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/13/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+
+final class LogInViewController: UIViewController {
+
+    deinit {
+        print("here")
+    }
+
+}

--- a/FightPandemics/Features/Profile/ProfileViewController.swift
+++ b/FightPandemics/Features/Profile/ProfileViewController.swift
@@ -28,4 +28,35 @@ import UIKit
 
 final class ProfileViewController: UIViewController {
 
+    // MARK: - Properties
+
+    var navigator: Navigator!
+    var sessionManager: SessionManager!
+
+    // MARK: - Overrides
+
+    // MARK: View life-cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupUI()
+    }
+
+    // MARK: - Instance methods
+
+    // MARK: Private instance methods
+
+    private func setupUI() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "LogOutCTA".localized,
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(logOut))
+    }
+
+    @objc private func logOut() {
+        sessionManager.logOut()
+        navigator.navigateToLogIn()
+    }
+
 }

--- a/FightPandemics/Features/Tab Bar/RootTabBarController.swift
+++ b/FightPandemics/Features/Tab Bar/RootTabBarController.swift
@@ -53,6 +53,10 @@ final class RootTabBarController: UITabBarController {
 
     // MARK: - Instance methods
 
+    func selectTab(_ tab: Tab) {
+        selectedIndex = tab.rawValue
+    }
+
     func navController(_ tab: Tab) -> UINavigationController? {
         return viewControllers?[tab.rawValue] as? UINavigationController
     }

--- a/FightPandemics/Features/Tab Bar/RootTabBarController.swift
+++ b/FightPandemics/Features/Tab Bar/RootTabBarController.swift
@@ -36,10 +36,34 @@ final class RootTabBarController: UITabBarController {
         case profile
     }
 
+    // MARK: - Properties
+
+    var navigator: Navigator!
+    var sessionManager: SessionManager!
+
+    // MARK: - Overrides
+
+    // MARK: View life-cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigateToLoginIfNeed()
+    }
+
     // MARK: - Instance methods
 
     func navController(_ tab: Tab) -> UINavigationController? {
         return viewControllers?[tab.rawValue] as? UINavigationController
+    }
+
+    // MARK: Private instance methods
+
+    private func navigateToLoginIfNeed() {
+        guard case .guest = sessionManager.authState else {
+            return
+        }
+        navigator.navigateToLogIn()
     }
 
 }

--- a/FightPandemics/Features/Tab Bar/RootTabBarController.swift
+++ b/FightPandemics/Features/Tab Bar/RootTabBarController.swift
@@ -38,6 +38,7 @@ final class RootTabBarController: UITabBarController {
 
     // MARK: - Properties
 
+    var autoLoginFakeLaunchScreen: AutoLoginFakeLaunchScreen!
     var navigator: Navigator!
     var sessionManager: SessionManager!
 
@@ -45,10 +46,10 @@ final class RootTabBarController: UITabBarController {
 
     // MARK: View life-cycle
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
-        navigateToLoginIfNeed()
+        attemptAutoLogIn()
     }
 
     // MARK: - Instance methods
@@ -63,11 +64,14 @@ final class RootTabBarController: UITabBarController {
 
     // MARK: Private instance methods
 
-    private func navigateToLoginIfNeed() {
-        guard case .guest = sessionManager.authState else {
-            return
+    private func attemptAutoLogIn() {
+        autoLoginFakeLaunchScreen.show()
+        sessionManager.autoLogIn { [weak self] result in
+            self?.autoLoginFakeLaunchScreen.dismiss()
+            if !(result == .success) {
+                self?.navigator.navigateToLogIn()
+            }
         }
-        navigator.navigateToLogIn()
     }
 
 }

--- a/FightPandemics/Models/API/Environment.swift
+++ b/FightPandemics/Models/API/Environment.swift
@@ -1,8 +1,8 @@
 //
-//  FightPandemicsAPI.swift
+//  Environment.swift
 //  FightPandemics
 //
-//  Created by Harlan Kellaway on 5/10/20.
+//  Created by Harlan Kellaway on 5/14/20.
 //
 //  Copyright (c) 2020 FightPandemics
 //
@@ -26,32 +26,9 @@
 
 import Foundation
 
-final class FightPandemicsAPI: API {
-
-    // MARK: - Properties
-
-    let baseURL: String
-    let httpClient: HTTPClient
-
-    // MARK: - Init/Deinit
-
-    init( baseURL: String, httpClient: HTTPClient) {
-        self.baseURL = baseURL
-        self.httpClient = httpClient
-    }
-
-    // MARK: - Protocol conformance
-
-    // MARK: API
-
-    func logIn(email: String, password: String, completion: @escaping (Result<User, APIError>) -> Void) {
-        assertionFailure("API not implemented yet")
-        completion(.failure(.unimplemented(endpoint: "/login")))
-    }
-
-    func logOut(completion: @escaping (Result<Success, APIError>) -> Void) {
-        assertionFailure("API not implemented yet")
-        completion(.failure(.unimplemented(endpoint: "/logout")))
-    }
-
+/// API environment.
+enum Environment {
+    case production
+    case staging
+    case mock
 }

--- a/FightPandemics/Models/API/FightPandemicsAPI.swift
+++ b/FightPandemics/Models/API/FightPandemicsAPI.swift
@@ -44,9 +44,14 @@ final class FightPandemicsAPI: API {
 
     // MARK: FightPandemicsAPI
 
-    func getUser(byID userID: String, completion: @escaping (Result<User, APIError>) -> Void) {
+    func logIn(email: String, password: String, completion: @escaping (Result<User, APIError>) -> Void) {
         assertionFailure("API not implemented yet")
-        completion(.failure(.unimplemented(endpoint: "/users/:userId")))
+        completion(.failure(.unimplemented(endpoint: "/login")))
+    }
+
+    func logOut(completion: @escaping (Result<Success, APIError>) -> Void) {
+        assertionFailure("API not implemented yet")
+        completion(.failure(.unimplemented(endpoint: "/logout")))
     }
 
 }

--- a/FightPandemics/Models/API/MockAPI.swift
+++ b/FightPandemics/Models/API/MockAPI.swift
@@ -32,16 +32,21 @@ final class MockAPI: API {
     let latency: DispatchTimeInterval
 
     init(jsonFileReader: JSONFileReader = JSONFileReader(),
-         latency: DispatchTimeInterval = .seconds(3)) {
+         latency: DispatchTimeInterval = .seconds(2)) {
         self.jsonFileReader = jsonFileReader
         self.latency = latency
     }
 
     func logIn(email: String, password: String, completion: @escaping (Result<User, APIError>) -> Void) {
         let user = jsonFileReader.read(fileNamed: "User", modelType: User.self)
+
         simulateNetworkDelay(then: {
             switch user {
             case .success(let user):
+                guard email == user.email else {
+                    completion(.failure(.httpClientError(value: .httpRequestError(error: .responseError(error: NSError(domain: "com.fp.fp", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid credentials"]))))))
+                    return
+                }
                 completion(.success(user))
             case .failure:
                 completion(.failure(.httpClientError(value: .jsonParsingFailed)))

--- a/FightPandemics/Models/API/Mocks/User.json
+++ b/FightPandemics/Models/API/Mocks/User.json
@@ -1,6 +1,6 @@
 {
     "id": "123",
-    "firstName": "Jane",
-    "lastName": "Domuch",
-    "email": "jane@do.co"
+    "firstName": "Lily",
+    "lastName": "Luke",
+    "email": "lily@luke.co"
 }

--- a/FightPandemics/Models/AuthCredentials.swift
+++ b/FightPandemics/Models/AuthCredentials.swift
@@ -1,8 +1,8 @@
 //
-//  FightPandemicsAPI.swift
+//  AuthCredentials.swift
 //  FightPandemics
 //
-//  Created by Harlan Kellaway on 5/10/20.
+//  Created by Harlan Kellaway on 5/13/20.
 //
 //  Copyright (c) 2020 FightPandemics
 //
@@ -26,32 +26,7 @@
 
 import Foundation
 
-final class FightPandemicsAPI: API {
-
-    // MARK: - Properties
-
-    let baseURL: String
-    let httpClient: HTTPClient
-
-    // MARK: - Init/Deinit
-
-    init( baseURL: String, httpClient: HTTPClient) {
-        self.baseURL = baseURL
-        self.httpClient = httpClient
-    }
-
-    // MARK: - Protocol conformance
-
-    // MARK: API
-
-    func logIn(email: String, password: String, completion: @escaping (Result<User, APIError>) -> Void) {
-        assertionFailure("API not implemented yet")
-        completion(.failure(.unimplemented(endpoint: "/login")))
-    }
-
-    func logOut(completion: @escaping (Result<Success, APIError>) -> Void) {
-        assertionFailure("API not implemented yet")
-        completion(.failure(.unimplemented(endpoint: "/logout")))
-    }
-
+struct AuthCredentials {
+    let email: String
+    let password: String
 }

--- a/FightPandemics/Models/Success.swift
+++ b/FightPandemics/Models/Success.swift
@@ -1,8 +1,8 @@
 //
-//  API.swift
+//  Success.swift
 //  FightPandemics
 //
-//  Created by Harlan Kellaway on 5/10/20.
+//  Created by Harlan Kellaway on 5/13/20.
 //
 //  Copyright (c) 2020 FightPandemics
 //
@@ -26,11 +26,5 @@
 
 import Foundation
 
-protocol API {
-
-    // MARK: - Auth
-
-    func logIn(email: String, password: String, completion: @escaping (Result<User, APIError>) -> Void)
-    func logOut(completion: @escaping (Result<Success, APIError>) -> Void)
-
-}
+/// Represents success value with no associated data.
+struct Success { }

--- a/FightPandemics/Resources/en.lproj/Localizable.strings
+++ b/FightPandemics/Resources/en.lproj/Localizable.strings
@@ -8,8 +8,10 @@
 
 // MARK: - Features
 
+// MARK: Auth
+
+"LogInCTA" = "Log In";
+
 // MARK: Feed
 
 "FeedPostViewMoreCTA" = "View More";
-
-// MARK: Home

--- a/FightPandemics/Resources/en.lproj/Localizable.strings
+++ b/FightPandemics/Resources/en.lproj/Localizable.strings
@@ -15,3 +15,7 @@
 // MARK: Feed
 
 "FeedPostViewMoreCTA" = "View More";
+
+// MARK: Profile
+
+"LogOutCTA" = "Log Out";

--- a/FightPandemics/SceneDelegate.swift
+++ b/FightPandemics/SceneDelegate.swift
@@ -44,6 +44,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         self.navigator = Navigator(rootWindow: window)
         self.navigator.installRootTabBar()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.navigator.navigateToLogIn()
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/FightPandemics/SceneDelegate.swift
+++ b/FightPandemics/SceneDelegate.swift
@@ -26,18 +26,11 @@
 
 import UIKit
 
-enum Environment {
-    case production
-    case staging
-    case mock
-}
-
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
     private(set) var currentEnvironment: Environment!
     private(set) var navigator: Navigator!
-    private(set) var sessionManager: SessionManager!
 
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
@@ -56,6 +49,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.currentEnvironment = .mock
         #endif
 
+        setupDependencies()
+        self.navigator.installRootTabBar()
+    }
+
+    private func setupDependencies() {
         let api: API
         switch self.currentEnvironment! {
         case .production:
@@ -66,9 +64,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             api = MockAPI()
         }
 
-        self.sessionManager = SessionManager(api: api, authState: .guest)
-        self.navigator = Navigator(rootWindow: window, sessionManager: sessionManager)
-        self.navigator.installRootTabBar()
+        let autoLoginFakeLaunchScreen = AutoLoginFakeLaunchScreen(rootWindow: window)
+        let sessionManager = SessionManager(api: api, authState: .guest)
+        self.navigator = Navigator(rootWindow: window,
+                                   autoLoginFakeLaunchScreen: autoLoginFakeLaunchScreen,
+                                   sessionManager: sessionManager)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/FightPandemics/Utilities/Navigation/Navigator.swift
+++ b/FightPandemics/Utilities/Navigation/Navigator.swift
@@ -35,7 +35,7 @@ final class Navigator {
 
     private let sessionManager: SessionManager
 
-    private(set) var rootWindow: UIWindow?
+    private var rootWindow: UIWindow?
     private var rootTabBar: RootTabBarController?
     private var logInNavigationController: UINavigationController?
     private var feedNavigationController: UINavigationController?
@@ -61,6 +61,7 @@ final class Navigator {
         logIn.modalPresentationStyle = .overFullScreen
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             self?.rootTabBar?.present(logIn, animated: true, completion: nil)
+            self?.rootTabBar?.selectTab(.feed)
         }
     }
 
@@ -105,6 +106,8 @@ final class Navigator {
     private func profileViewController() -> ProfileViewController {
         let profileViewController = UIStoryboard(name: "Profile", bundle: nil)
             .instantiateViewController(withIdentifier: "ProfileViewController") as! ProfileViewController
+        profileViewController.navigator = self
+        profileViewController.sessionManager = sessionManager
         return profileViewController
     }
 

--- a/FightPandemics/Utilities/Navigation/Navigator.swift
+++ b/FightPandemics/Utilities/Navigation/Navigator.swift
@@ -33,19 +33,20 @@ final class Navigator {
 
     // MARK: - Properties
 
-    private let sessionManager: SessionManager
-
     private var rootWindow: UIWindow?
     private var rootTabBar: RootTabBarController?
     private var logInNavigationController: UINavigationController?
     private var feedNavigationController: UINavigationController?
     private var searchNavigationController: UINavigationController?
     private var profileNavigationController: UINavigationController?
+    private let autoLoginFakeLaunchScreen: AutoLoginFakeLaunchScreen
+    private let sessionManager: SessionManager
 
     // MARK: - Init/Deinit
 
-    init(rootWindow: UIWindow?, sessionManager: SessionManager) {
+    init(rootWindow: UIWindow?, autoLoginFakeLaunchScreen: AutoLoginFakeLaunchScreen, sessionManager: SessionManager) {
         self.rootWindow = rootWindow
+        self.autoLoginFakeLaunchScreen = autoLoginFakeLaunchScreen
         self.sessionManager = sessionManager
     }
 
@@ -56,9 +57,10 @@ final class Navigator {
     }
 
     func navigateToLogIn() {
-        // Can be displayed at launch; slignt delay to give initial UI time to setup
         let logIn = logInNavController()
         logIn.modalPresentationStyle = .overFullScreen
+
+        // Slight delay to give initial UI time to setup in the event Log In presented right at launch
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             self?.rootTabBar?.present(logIn, animated: true, completion: nil)
             self?.rootTabBar?.selectTab(.feed)
@@ -77,6 +79,7 @@ final class Navigator {
         let rootTabBarController = UIStoryboard(name: "Main", bundle: nil)
             .instantiateViewController(withIdentifier: "RootTabBarController") as! RootTabBarController
         self.rootTabBar = rootTabBarController
+        rootTabBarController.autoLoginFakeLaunchScreen = autoLoginFakeLaunchScreen
         rootTabBarController.navigator = self
         rootTabBarController.sessionManager = sessionManager
         let feedNavigationController = rootTabBarController.navController(.feed)
@@ -123,6 +126,7 @@ final class Navigator {
         let logInViewController = UIStoryboard(name: "Auth", bundle: nil)
             .instantiateViewController(withIdentifier: "LogInViewController") as! LogInViewController
         logInViewController.navigator = self
+        logInViewController.sessionManager = sessionManager
         return logInViewController
     }
 

--- a/FightPandemics/Utilities/Navigation/Navigator.swift
+++ b/FightPandemics/Utilities/Navigation/Navigator.swift
@@ -36,6 +36,8 @@ final class Navigator {
     /// Root window of application.
     private(set) var rootWindow: UIWindow?
 
+    private var rootTabBar: RootTabBarController?
+    private var logInNavigationController: UINavigationController?
     private var feedNavigationController: UINavigationController?
     private var searchNavigationController: UINavigationController?
     private var profileNavigationController: UINavigationController?
@@ -52,9 +54,22 @@ final class Navigator {
         rootWindow?.rootViewController = rootTabBarController()
     }
 
+    func navigateToLogIn() {
+        rootTabBar?.present(logInNavController(), animated: true, completion: nil)
+    }
+
+    func dismissLogIn() {
+        rootTabBar?.dismiss(animated: true) { [weak self] in
+            self?.logInNavigationController = nil
+        }
+    }
+
+    // MARK: Private instance methods
+
     private func rootTabBarController() -> RootTabBarController {
         let rootTabBarController = UIStoryboard(name: "Main", bundle: nil)
             .instantiateViewController(withIdentifier: "RootTabBarController") as! RootTabBarController
+        self.rootTabBar = rootTabBarController
         let feedNavigationController = rootTabBarController.navController(.feed)
         self.feedNavigationController = feedNavigationController
         feedNavigationController?.pushViewController(feedViewController(), animated: false)
@@ -83,6 +98,20 @@ final class Navigator {
         let profileViewController = UIStoryboard(name: "Profile", bundle: nil)
             .instantiateViewController(withIdentifier: "ProfileViewController") as! ProfileViewController
         return profileViewController
+    }
+
+    private func logInNavController() -> UINavigationController {
+        let logInNavigationController = UIStoryboard(name: "Auth", bundle: nil)
+            .instantiateViewController(withIdentifier: "LogInNavigationController") as! UINavigationController
+        self.logInNavigationController = logInNavigationController
+        logInNavigationController.pushViewController(logInViewController(), animated: false)
+        return logInNavigationController
+    }
+
+    private func logInViewController() -> LogInViewController {
+        let logInViewController = UIStoryboard(name: "Auth", bundle: nil)
+            .instantiateViewController(withIdentifier: "LogInViewController") as! LogInViewController
+        return logInViewController
     }
 
 }

--- a/FightPandemics/Utilities/Navigation/Navigator.swift
+++ b/FightPandemics/Utilities/Navigation/Navigator.swift
@@ -111,6 +111,7 @@ final class Navigator {
     private func logInViewController() -> LogInViewController {
         let logInViewController = UIStoryboard(name: "Auth", bundle: nil)
             .instantiateViewController(withIdentifier: "LogInViewController") as! LogInViewController
+        logInViewController.navigator = self
         return logInViewController
     }
 

--- a/FightPandemics/Utilities/Navigation/Navigator.swift
+++ b/FightPandemics/Utilities/Navigation/Navigator.swift
@@ -33,9 +33,9 @@ final class Navigator {
 
     // MARK: - Properties
 
-    /// Root window of application.
-    private(set) var rootWindow: UIWindow?
+    private let sessionManager: SessionManager
 
+    private(set) var rootWindow: UIWindow?
     private var rootTabBar: RootTabBarController?
     private var logInNavigationController: UINavigationController?
     private var feedNavigationController: UINavigationController?
@@ -44,8 +44,9 @@ final class Navigator {
 
     // MARK: - Init/Deinit
 
-    init(rootWindow: UIWindow?) {
+    init(rootWindow: UIWindow?, sessionManager: SessionManager) {
         self.rootWindow = rootWindow
+        self.sessionManager = sessionManager
     }
 
     // MARK: - Instance methods
@@ -55,7 +56,12 @@ final class Navigator {
     }
 
     func navigateToLogIn() {
-        rootTabBar?.present(logInNavController(), animated: true, completion: nil)
+        // Can be displayed at launch; slignt delay to give initial UI time to setup
+        let logIn = logInNavController()
+        logIn.modalPresentationStyle = .overFullScreen
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.rootTabBar?.present(logIn, animated: true, completion: nil)
+        }
     }
 
     func dismissLogIn() {
@@ -70,6 +76,8 @@ final class Navigator {
         let rootTabBarController = UIStoryboard(name: "Main", bundle: nil)
             .instantiateViewController(withIdentifier: "RootTabBarController") as! RootTabBarController
         self.rootTabBar = rootTabBarController
+        rootTabBarController.navigator = self
+        rootTabBarController.sessionManager = sessionManager
         let feedNavigationController = rootTabBarController.navController(.feed)
         self.feedNavigationController = feedNavigationController
         feedNavigationController?.pushViewController(feedViewController(), animated: false)

--- a/FightPandemics/Utilities/Session Manager/SessionManager.swift
+++ b/FightPandemics/Utilities/Session Manager/SessionManager.swift
@@ -48,7 +48,7 @@ final class SessionManager {
     }
 
     // MARK: - Instance methods
-    
+
     func logIn(email: String, password: String, completion: @escaping (Result<Success, SessionManagerError>) -> Void) {
         api.logIn(email: email, password: password) { [weak self] result in
             switch result {
@@ -60,7 +60,7 @@ final class SessionManager {
             }
         }
     }
-    
+
     func logOut() {
         api.logOut { _ in
             // Regardless of whether backend is successful cleaning up session,

--- a/FightPandemics/Utilities/Session Manager/SessionManagerError.swift
+++ b/FightPandemics/Utilities/Session Manager/SessionManagerError.swift
@@ -1,8 +1,8 @@
 //
-//  MockAPI.swift
+//  SessionManagerError.swift
 //  FightPandemics
 //
-//  Created by Harlan Kellaway on 5/10/20.
+//  Created by Harlan Kellaway on 5/13/20.
 //
 //  Copyright (c) 2020 FightPandemics
 //
@@ -26,38 +26,13 @@
 
 import Foundation
 
-final class MockAPI: API {
+enum SessionManagerError: Error, LocalizedError {
+    case apiError(value: APIError)
 
-    let jsonFileReader: JSONFileReader
-    let latency: DispatchTimeInterval
-
-    init(jsonFileReader: JSONFileReader = JSONFileReader(),
-         latency: DispatchTimeInterval = .seconds(3)) {
-        self.jsonFileReader = jsonFileReader
-        self.latency = latency
-    }
-
-    func logIn(email: String, password: String, completion: @escaping (Result<User, APIError>) -> Void) {
-        let user = jsonFileReader.read(fileNamed: "User", modelType: User.self)
-        simulateNetworkDelay(then: {
-            switch user {
-            case .success(let user):
-                completion(.success(user))
-            case .failure:
-                completion(.failure(.httpClientError(value: .jsonParsingFailed)))
-            }
-        })
-    }
-
-    func logOut(completion: @escaping (Result<Success, APIError>) -> Void) {
-        simulateNetworkDelay(then: {
-            completion(.success(Success()))
-        })
-    }
-
-    private func simulateNetworkDelay(then: @escaping () -> Void) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + latency) {
-            then()
+    var errorDescription: String? {
+        switch self {
+        case .apiError(let error):
+            return error.localizedDescription
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If this is your first time, please read our contributor guidelines: https://github.com/FightPandemics/FightPandemics-iOS/blob/develop/CONTRIBUTING.md
-->

**What this PR does**:

This PR adds in the typical flow and infrastructure for Log In. Specifically it:
* Attempts to auto-login the user at app launch
* If successful, user is moved into app
* If unsuccessful, user is presented the Log In screen

This uses the mock `API` as we'd expect to use an actual API and introduces a `SessionManager` to manage authenticated state as we'd expect to.

You will find a Log Out button on Profile that will also present the Log In screen. Tapping the button on the Log In screen mocks a Log In.

### Checklist

[x] Compiler warnings resolved
[x] Linter warnings resolved (intentionally added TODOs)
[x] User-facing strings in Localizable.strings file
[x] Unused code, print statements, and comments removed

**Special notes for reviewers**:

You'll find `SceneDelegate` and `Navigator` doing a lot of dependency creation and injection - this is intentional. For now that behavior is kept there for consistency; to be refactored in a separate PR after discussing architecture with the group.