### PR TITLE
Programmatic Constraints utility

### DIFF
--- a/FightPandemics.xcodeproj/project.pbxproj
+++ b/FightPandemics.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		2F0B5168246E0DF200BE42BC /* CreatePostBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0B5165246E0DF200BE42BC /* CreatePostBody.swift */; };
 		2F0B516B246E15B400BE42BC /* IndividualOrg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0B516A246E15B400BE42BC /* IndividualOrg.swift */; };
 		2F0C3C44246F51BB0002B384 /* PostReactionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C3C43246F51BA0002B384 /* PostReactionButton.swift */; };
+		2F0C3C40246ECA5C0002B384 /* Constraints+FightPandemics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C3C3F246ECA5C0002B384 /* Constraints+FightPandemics.swift */; };
+		2F0C3C42246ECA660002B384 /* ConstrainableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C3C41246ECA660002B384 /* ConstrainableView.swift */; };
 		2F72CE4D2468785200750785 /* HTTPClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE462468785200750785 /* HTTPClientError.swift */; };
 		2F72CE4E2468785200750785 /* HTTPRequestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE472468785200750785 /* HTTPRequestError.swift */; };
 		2F72CE4F2468785200750785 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F72CE482468785200750785 /* HTTPRequest.swift */; };
@@ -125,6 +127,8 @@
 		2F0B5165246E0DF200BE42BC /* CreatePostBody.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreatePostBody.swift; sourceTree = "<group>"; };
 		2F0B516A246E15B400BE42BC /* IndividualOrg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndividualOrg.swift; sourceTree = "<group>"; };
 		2F0C3C43246F51BA0002B384 /* PostReactionButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostReactionButton.swift; sourceTree = "<group>"; };
+		2F0C3C3F246ECA5C0002B384 /* Constraints+FightPandemics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constraints+FightPandemics.swift"; sourceTree = "<group>"; };
+		2F0C3C41246ECA660002B384 /* ConstrainableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrainableView.swift; sourceTree = "<group>"; };
 		2F72CE462468785200750785 /* HTTPClientError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClientError.swift; sourceTree = "<group>"; };
 		2F72CE472468785200750785 /* HTTPRequestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequestError.swift; sourceTree = "<group>"; };
 		2F72CE482468785200750785 /* HTTPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
@@ -293,6 +297,15 @@
 			path = IndividualOrg;
 			sourceTree = "<group>";
 		};
+		2F0C3C3E246ECA460002B384 /* Constraints */ = {
+			isa = PBXGroup;
+			children = (
+				2F0C3C41246ECA660002B384 /* ConstrainableView.swift */,
+				2F0C3C3F246ECA5C0002B384 /* Constraints+FightPandemics.swift */,
+			);
+			path = Constraints;
+			sourceTree = "<group>";
+		};
 		2F72CE452468785200750785 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
@@ -379,6 +392,7 @@
 		2F9EFE68245DFC9F00E86700 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				2F0C3C3E246ECA460002B384 /* Constraints */,
 				2FB341EA2468F841007E397F /* Extensions */,
 				DC807E67247027C700046D67 /* FileReader */,
 				2FB342022468FFC3007E397F /* Navigation */,
@@ -717,6 +731,8 @@
 				2F72CE532468785200750785 /* HTTPClient.swift in Sources */,
 				2F0B515C246E009400BE42BC /* CreatePostViewController.swift in Sources */,
 				2F0B516B246E15B400BE42BC /* IndividualOrg.swift in Sources */,
+				2F0C3C40246ECA5C0002B384 /* Constraints+FightPandemics.swift in Sources */,
+				2F72CE6424687C9A00750785 /* JSONFileReaderError.swift in Sources */,
 				2F042110246A1021005FB1D0 /* PostFooter.swift in Sources */,
 				DC807E64246FB37000046D67 /* BottomModalTransitionDelegate.swift in Sources */,
 				2F0420F9246A0E7E005FB1D0 /* FeedPrototypeViewController.swift in Sources */,
@@ -729,6 +745,7 @@
 				DC807E5B246FB02300046D67 /* Entity.swift in Sources */,
 				2F72CE5D2468793300750785 /* MockAPI.swift in Sources */,
 				2F042194246CD022005FB1D0 /* SearchViewController.swift in Sources */,
+				2F0C3C42246ECA660002B384 /* ConstrainableView.swift in Sources */,
 				2F0B5166246E0DF200BE42BC /* CreatePostFooter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FightPandemics/Features/Auth/AutoLogInFakeLaunchScreen.swift
+++ b/FightPandemics/Features/Auth/AutoLogInFakeLaunchScreen.swift
@@ -44,23 +44,13 @@ final class AutoLoginFakeLaunchScreen {
 
         // TODO: UI should match Launch screen https://github.com/FightPandemics/FightPandemics-iOS/issues/52
         containerView.backgroundColor = .white
-        containerView.translatesAutoresizingMaskIntoConstraints = false
-        rootView.addSubview(containerView)
-        NSLayoutConstraint.activate([
-            containerView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
-            containerView.topAnchor.constraint(equalTo: rootView.topAnchor),
-            containerView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
-            containerView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor)
-        ])
+        containerView.makeSubview(of: rootView)
+            .pinToEdges()
 
         loadingSpinner.color = .darkGray
         loadingSpinner.startAnimating()
-        loadingSpinner.translatesAutoresizingMaskIntoConstraints = false
-        containerView.addSubview(loadingSpinner)
-        NSLayoutConstraint.activate([
-            loadingSpinner.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-            loadingSpinner.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
-        ])
+        loadingSpinner.makeSubview(of: containerView)
+            .center()
     }
 
     func dismiss() {

--- a/FightPandemics/Features/Auth/LogInViewController.swift
+++ b/FightPandemics/Features/Auth/LogInViewController.swift
@@ -57,13 +57,9 @@ final class LogInViewController: UIViewController {
         title = "Tap Log In >>>"
         view.backgroundColor = .systemTeal
 
-        loadingSpinner.translatesAutoresizingMaskIntoConstraints = false
         loadingSpinner.color = .white
-        view.addSubview(loadingSpinner)
-        NSLayoutConstraint.activate([
-            loadingSpinner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            loadingSpinner.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ])
+        loadingSpinner.makeSubview(of: view)
+            .center()
     }
 
     @objc private func logIn() {

--- a/FightPandemics/Features/Feed/FeedPost/FeedPost.swift
+++ b/FightPandemics/Features/Feed/FeedPost/FeedPost.swift
@@ -45,7 +45,6 @@ class FeedPost: UIView {
         typeLabel.layer.borderColor = UIColor(hexString: "#425AF2").cgColor
         typeLabel.layer.borderWidth = 1
         typeLabel.layer.cornerRadius = typeLabel.frame.size.height / 2
-        self.addSubview(typeLabel)
         // title label
         titleLabel.text = title
         titleLabel.textAlignment = .left
@@ -55,7 +54,6 @@ class FeedPost: UIView {
         titleLabel.layoutIfNeeded()
         titleLabel.textColor = UIColor(hexString: "#282828")
         titleLabel.backgroundColor = UIColor.clear
-        self.addSubview(titleLabel)
         // body label
         bodyLabel.text = body
         bodyLabel.textAlignment = .left
@@ -65,37 +63,34 @@ class FeedPost: UIView {
         bodyLabel.layoutIfNeeded()
         bodyLabel.textColor = UIColor(hexString: "#282828")
         bodyLabel.backgroundColor = UIColor.clear
-        self.addSubview(bodyLabel)
         // more button
         moreButton.setTitle("FeedPostViewMoreCTA".localized, for: .normal)
         moreButton.setTitleColor(UIColor(hexString: "#425AF2"), for: .normal)
         moreButton.titleLabel?.font = UIFont(name: "System", size: 16)
         moreButton.contentHorizontalAlignment = .left
         moreButton.backgroundColor = UIColor.clear
-        self.addSubview(moreButton)
         makeConstraints()
     }
 
     private func makeConstraints () {
-        self.translatesAutoresizingMaskIntoConstraints = false
-        typeLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint(item: typeLabel, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leading, multiplier: 1, constant: 23).isActive = true
-        NSLayoutConstraint(item: typeLabel, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1, constant: 74).isActive = true
-        NSLayoutConstraint(item: typeLabel, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 24).isActive = true
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint(item: titleLabel, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: UIScreen.main.bounds.width).isActive = true
-        NSLayoutConstraint(item: titleLabel, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1, constant: 24).isActive = true
-        NSLayoutConstraint(item: titleLabel, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1, constant: 23).isActive = true
-        NSLayoutConstraint(item: titleLabel, attribute: .top, relatedBy: .equal, toItem: typeLabel, attribute: .bottom, multiplier: 1, constant: 9).isActive = true
-        bodyLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint(item: bodyLabel, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: UIScreen.main.bounds.width - 47).isActive = true
-        NSLayoutConstraint(item: bodyLabel, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leading, multiplier: 1, constant: 24).isActive = true
-        NSLayoutConstraint(item: bodyLabel, attribute: .trailing, relatedBy: .equal, toItem: self, attribute: .trailing, multiplier: 1, constant: 23).isActive = true
-        NSLayoutConstraint(item: bodyLabel, attribute: .top, relatedBy: .equal, toItem: titleLabel, attribute: .bottom, multiplier: 1, constant: 9).isActive = true
-        moreButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint(item: moreButton, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1, constant: 24).isActive = true
-        NSLayoutConstraint(item: moreButton, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1, constant: 24).isActive = true
-        NSLayoutConstraint(item: moreButton, attribute: .top, relatedBy: .equal, toItem: bodyLabel, attribute: .bottom, multiplier: 1, constant: 16).isActive = true
-        NSLayoutConstraint(item: moreButton, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1, constant: 0).isActive = true
+        typeLabel.makeSubview(of: self)
+            .leading(to: \.leadingAnchor, constant: 23)
+            .top(to: \.topAnchor, constant: 74)
+            .height(24)
+        titleLabel.makeSubview(of: self)
+            .width(UIScreen.main.bounds.width)
+            .leading(to: \.leadingAnchor, constant: 24)
+            .trailing(to: \.trailingAnchor, constant: 23)
+            .top(to: \.topAnchor, constant: 9)
+        bodyLabel.makeSubview(of: self)
+            .width(UIScreen.main.bounds.width - 47)
+            .leading(to: \.leadingAnchor, constant: 24)
+            .trailing(to: \.trailingAnchor, constant: 23)
+            .top(to: \.topAnchor, of: titleLabel, constant: 9)
+        moreButton.makeSubview(of: self)
+            .leading(to: \.leadingAnchor, constant: 24)
+            .trailing(to: \.trailingAnchor, constant: 24)
+            .top(to: \.topAnchor, of: bodyLabel, constant: 16)
+            .bottom(to: \.bottomAnchor)
     }
 }

--- a/FightPandemics/Features/Shared/TagView.swift
+++ b/FightPandemics/Features/Shared/TagView.swift
@@ -37,7 +37,6 @@ class TagView: UIView {
         label.textAlignment = .center
         label.adjustsFontSizeToFitWidth = true
         label.adjustsFontForContentSizeCategory = true
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
 
@@ -64,12 +63,11 @@ class TagView: UIView {
     }
 
     func initializeUI() {
-        self.addSubview(title)
-        addAutoLayout()
+        title.makeSubview(of: self)
+            .pinToEdges().height(22)
         addTapGesture()
 
         self.backgroundColor = UIColor(named: "TagBackgroundGrayColor")
-        self.translatesAutoresizingMaskIntoConstraints = false
         self.layer.cornerRadius = 5
     }
 
@@ -91,13 +89,4 @@ class TagView: UIView {
         }
     }
 
-    func addAutoLayout() {
-        NSLayoutConstraint.activate([
-            title.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            title.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            title.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            title.topAnchor.constraint(equalTo: self.topAnchor),
-            title.heightAnchor.constraint(equalToConstant: 22)
-        ])
-    }
 }

--- a/FightPandemics/Utilities/Constraints/ConstrainableView.swift
+++ b/FightPandemics/Utilities/Constraints/ConstrainableView.swift
@@ -1,0 +1,260 @@
+//
+//  ConstrainableView.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/15/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+
+/// View assumed to have a state and follow usage compatible with being constrained programmatically.
+protocol ConstrainableView: class {
+    var superview: UIView? { get }
+    var target: UIView { get }
+}
+
+extension UIView: ConstrainableView {
+
+    var target: UIView {
+        return self
+    }
+
+}
+
+extension ConstrainableView {
+
+    /// Adds this view as a child of the provided view. Prefer over `addSubview`.
+    ///  - Postcondition: After calling, this view will be prepared to work with programmatic constraints.
+    /// - Parameter other: View to make this view a child of.
+    @discardableResult
+    func makeSubview(of other: UIView) -> Self {
+        target.translatesAutoresizingMaskIntoConstraints = false
+        other.addSubview(target)
+        return self
+    }
+
+    // MARK: - Chainable Constraints
+
+    // MARK: Convenience
+
+    @discardableResult
+    func pinToEdges(of view: UIView? = nil, withMargin margin: CGFloat = 0, useSafeArea: Bool = false) -> Self {
+        let insets = UIEdgeInsets(top: margin, left: margin, bottom: margin, right: margin)
+        return pinToEdges(of: view, withInsets: insets, useSafeArea: useSafeArea)
+    }
+
+    @discardableResult
+    func pinToEdges(of view: UIView? = nil, withInsets insets: UIEdgeInsets, useSafeArea: Bool = false) -> Self {
+        if useSafeArea {
+            return top(to: \.safeAreaLayoutGuide.topAnchor, of: view, constant: insets.top)
+                .right(to: \.safeAreaLayoutGuide.rightAnchor, of: view, constant: insets.right)
+                .bottom(to: \.safeAreaLayoutGuide.bottomAnchor, of: view, constant: insets.bottom)
+                .left(to: \.safeAreaLayoutGuide.leftAnchor, of: view, constant: insets.left)
+        }
+
+        return top(to: \.topAnchor, of: view, constant: insets.top)
+            .right(to: \.rightAnchor, of: view, constant: insets.right)
+            .bottom(to: \.bottomAnchor, of: view, constant: insets.bottom)
+            .left(to: \.leftAnchor, of: view, constant: insets.left)
+    }
+
+    @discardableResult
+    func center(in view: UIView? = nil, withMargin margin: CGFloat = 0, relation: NSLayoutConstraint.Relation = .equal) -> Self {
+        return centerX(to: \.centerXAnchor, of: view, relation: relation, constant: margin)
+            .centerY(to: \.centerYAnchor, of: view, relation: relation, constant: margin)
+    }
+
+    @discardableResult
+    func size(_ size: CGSize, relation: NSLayoutConstraint.Relation = .equal) -> Self {
+        return width(size.width, relation: relation)
+            .height(size.height, relation: relation)
+    }
+
+    // MARK: NSLayoutDimension
+
+    @discardableResult
+    func width(
+        _ constant: CGFloat,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required
+        ) -> Self {
+        target.addWidthConstraint(constant, relation: relation, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func width<XAxisDimension>(
+        to dimension: KeyPath<UIView, XAxisDimension>,
+        of otherView: UIView? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required
+        ) -> Self where XAxisDimension: NSLayoutDimension {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addWidthConstraint(to: dimension, of: view!, multiplier: multiplier, constant: constant, relation: relation, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func height(
+        _ constant: CGFloat,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required
+        ) -> Self {
+        target.addHeightConstraint(constant, relation: relation, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func height<YAxisDimension>(
+        to dimension: KeyPath<UIView, YAxisDimension>,
+        of otherView: UIView? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required
+        ) -> Self where YAxisDimension: NSLayoutDimension {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addHeightConstraint(to: dimension, of: view!, multiplier: multiplier, constant: constant, relation: relation, priority: priority)
+        return self
+    }
+
+    // MARK: NSLayoutXAsixAnchor
+
+    @discardableResult
+    func leading<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> Self where XAxisAnchor: NSLayoutXAxisAnchor {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addLeadingConstraint(to: anchor, of: view!, relation: relation, constant: constant, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func trailing<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> Self where XAxisAnchor: NSLayoutXAxisAnchor {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addTrailingConstraint(to: anchor, of: view!, relation: relation, constant: constant, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func left<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> Self where XAxisAnchor: NSLayoutXAxisAnchor {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addLeftConstraint(to: anchor, of: view!, relation: relation, constant: constant, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func right<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> Self where XAxisAnchor: NSLayoutXAxisAnchor {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addRightConstraint(to: anchor, of: view!, relation: relation, constant: constant, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func centerX<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> Self where XAxisAnchor: NSLayoutXAxisAnchor {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addCenterXConstraint(to: anchor, of: view!, relation: relation, constant: constant, priority: priority)
+        return self
+    }
+
+    // MARK: NSLayoutYAxisAnchor
+
+    @discardableResult
+    func top<YAxisAnchor>(
+        to anchor: KeyPath<UIView, YAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> Self where YAxisAnchor: NSLayoutYAxisAnchor {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addTopConstraint(to: anchor, of: view!, relation: relation, constant: constant, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func bottom<YAxisAnchor>(
+        to anchor: KeyPath<UIView, YAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> Self where YAxisAnchor: NSLayoutYAxisAnchor {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addBottomConstraint(to: anchor, of: view!, relation: relation, constant: constant, priority: priority)
+        return self
+    }
+
+    @discardableResult
+    func centerY<YAxisAnchor>(
+        to anchor: KeyPath<UIView, YAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> Self where YAxisAnchor: NSLayoutYAxisAnchor {
+        let view = otherView ?? superview
+        precondition(view != nil, "ConstrainableView assumes a view to constrain to.")
+        target.addCenterYConstraint(to: anchor, of: view!, relation: relation, constant: constant, priority: priority)
+        return self
+    }
+
+}

--- a/FightPandemics/Utilities/Constraints/Constraints+FightPandemics.swift
+++ b/FightPandemics/Utilities/Constraints/Constraints+FightPandemics.swift
@@ -1,0 +1,331 @@
+//
+//  Constraints+FightPandemics.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/15/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+
+/// Constraint utility.
+/// - Remark: Inspired by jdisho/VanillaConstraints.
+
+extension UIView {
+
+    // MARK: NSLayoutDimension
+
+    @discardableResult
+    func addWidthConstraint(
+        _ constant: CGFloat,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+        return widthAnchor
+            .constraint(toConstant: constant, relation: relation)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addWidthConstraint<XAxisDimension>(
+        to dimension: KeyPath<UIView, XAxisDimension>,
+        of otherView: UIView? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where XAxisDimension: NSLayoutDimension {
+        guard let otherView = otherView else { return nil }
+        return widthAnchor
+            .constraint(to: otherView[keyPath: dimension], multiplier: multiplier, relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addHeightConstraint(
+        _ constant: CGFloat,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+        return heightAnchor
+            .constraint(toConstant: constant, relation: relation)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addHeightConstraint<YAxisDimension>(
+        to dimension: KeyPath<UIView, YAxisDimension>,
+        of otherView: UIView? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where YAxisDimension: NSLayoutDimension {
+        guard let otherView = otherView else { return nil }
+        return heightAnchor
+            .constraint(to: otherView[keyPath: dimension], multiplier: multiplier, relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    // MARK: NSLayoutXAxisAnchor
+
+    @discardableResult
+    func addLeadingConstraint<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where XAxisAnchor: NSLayoutXAxisAnchor {
+        guard let otherView = otherView else { return nil }
+        return leadingAnchor
+            .constraint(to: otherView[keyPath: anchor], relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addTrailingConstraint<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where XAxisAnchor: NSLayoutXAxisAnchor {
+        guard let otherView = otherView else { return nil }
+        return trailingAnchor
+            .constraint(to: otherView[keyPath: anchor], relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addLeftConstraint<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where XAxisAnchor: NSLayoutXAxisAnchor {
+        guard let otherView = otherView else { return nil }
+        return leftAnchor
+            .constraint(to: otherView[keyPath: anchor], relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addRightConstraint<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where XAxisAnchor: NSLayoutXAxisAnchor {
+        guard let otherView = otherView else { return nil }
+        return rightAnchor
+            .constraint(to: otherView[keyPath: anchor], relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addCenterXConstraint<XAxisAnchor>(
+        to anchor: KeyPath<UIView, XAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where XAxisAnchor: NSLayoutXAxisAnchor {
+        guard let otherView = otherView else { return nil }
+        return centerXAnchor
+            .constraint(to: otherView[keyPath: anchor], relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    // MARK: NSLayoutYAxisAnchor
+
+    @discardableResult
+    func addTopConstraint<YAxisAnchor>(
+        to anchor: KeyPath<UIView, YAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where YAxisAnchor: NSLayoutYAxisAnchor {
+        guard let otherView = otherView else { return nil }
+        return topAnchor
+            .constraint(to: otherView[keyPath: anchor], relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addBottomConstraint<YAxisAnchor>(
+        to anchor: KeyPath<UIView, YAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where YAxisAnchor: NSLayoutYAxisAnchor {
+        guard let otherView = otherView else { return nil }
+        return bottomAnchor
+            .constraint(to: otherView[keyPath: anchor], relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+    @discardableResult
+    func addCenterYConstraint<YAxisAnchor>(
+        to anchor: KeyPath<UIView, YAxisAnchor>,
+        of otherView: UIView? = nil,
+        relation: NSLayoutConstraint.Relation = .equal,
+        constant: CGFloat = 0,
+        priority: UILayoutPriority = .required
+        ) -> NSLayoutConstraint? where YAxisAnchor: NSLayoutYAxisAnchor {
+        guard let otherView = otherView else { return nil }
+        return centerYAnchor
+            .constraint(to: otherView[keyPath: anchor], relation: relation)
+            .offset(constant)
+            .priority(priority)
+            .activate()
+    }
+
+}
+
+// MARK: - NSLayoutDimension
+
+extension NSLayoutDimension {
+
+    fileprivate func constraint(
+        to dimension: NSLayoutDimension,
+        multiplier: CGFloat,
+        relation: NSLayoutConstraint.Relation
+        ) -> NSLayoutConstraint {
+        switch relation {
+        case .equal:
+            return constraint(equalTo: dimension, multiplier: multiplier)
+        case .lessThanOrEqual:
+            return constraint(lessThanOrEqualTo: dimension, multiplier: multiplier)
+        case .greaterThanOrEqual:
+            return constraint(greaterThanOrEqualTo: dimension, multiplier: multiplier)
+        @unknown default:
+            fatalError("Unexpected value provided by framework.")
+        }
+    }
+
+    fileprivate func constraint(
+        toConstant constant: CGFloat,
+        relation: NSLayoutConstraint.Relation = .equal
+        ) -> NSLayoutConstraint {
+        switch relation {
+        case .equal:
+            return constraint(equalToConstant: constant)
+        case .lessThanOrEqual:
+            return constraint(lessThanOrEqualToConstant: constant)
+        case .greaterThanOrEqual:
+            return constraint(greaterThanOrEqualToConstant: constant)
+        @unknown default:
+            fatalError("Unexpected value provided by framework.")
+        }
+    }
+
+}
+
+// MARK: - NSLayoutXAxisAnchor
+
+extension NSLayoutXAxisAnchor {
+
+    fileprivate func constraint(to anchor: NSLayoutXAxisAnchor,
+                                relation: NSLayoutConstraint.Relation) -> NSLayoutConstraint {
+        switch relation {
+        case .equal:
+            return constraint(equalTo: anchor)
+        case .lessThanOrEqual:
+            return constraint(lessThanOrEqualTo: anchor)
+        case .greaterThanOrEqual:
+            return constraint(greaterThanOrEqualTo: anchor)
+        @unknown default:
+            fatalError("Unexpected value provided by framework.")
+        }
+    }
+
+}
+
+// MARK: - NSLayoutYAxisAnchor
+
+extension NSLayoutYAxisAnchor {
+
+    fileprivate func constraint(to anchor: NSLayoutYAxisAnchor,
+                                relation: NSLayoutConstraint.Relation) -> NSLayoutConstraint {
+        switch relation {
+        case .equal:
+            return constraint(equalTo: anchor)
+        case .lessThanOrEqual:
+            return constraint(lessThanOrEqualTo: anchor)
+        case .greaterThanOrEqual:
+            return constraint(greaterThanOrEqualTo: anchor)
+        @unknown default:
+            fatalError("Unexpected value provided by framework.")
+        }
+    }
+
+}
+
+// MARK: - NSLayoutConstraint
+
+extension NSLayoutConstraint {
+
+    fileprivate func priority(_ priority: UILayoutPriority) -> Self {
+        self.priority = priority
+        return self
+    }
+
+    fileprivate func offset(_ offset: CGFloat) -> Self {
+        constant = offset
+        return self
+    }
+
+    fileprivate func activate() -> Self {
+        isActive = true
+        return self
+    }
+
+    fileprivate func deactivate() -> Self {
+        isActive = false
+        return self
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If this is your first time, please read our contributor guidelines: https://github.com/FightPandemics/FightPandemics-iOS/blob/develop/CONTRIBUTING.md
-->

**What this PR does**:

Adds a util that simplifies the boilerplate required to make programmatic constraints

Heavily inspired by [jdisho/VanillaConstraints](https://github.com/jdisho/VanillaConstraints)

### Checklist

[x] Compiler warnings resolved
[x] Linter warnings resolved
[x] User-facing strings in Localizable.strings file
[x] Unused code, print statements, and comments removed

**Which issue(s) this PR fixes**:

Resolves #

**Special notes for reviewers**:

**Additional comments**:

While it's popular to use great libs like `SnapKit` or `Cartography` - my personal philosophy on third-party libraries is often we don't need them. If a couple files like this keep us from maintaining an extra dependency - especially one like this that becomes almost impossible to extract - then that's a more manageable route. 

