### PR TITLE
Create Location Services utility

### DIFF
--- a/FightPandemics.xcodeproj/project.pbxproj
+++ b/FightPandemics.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		2FB341F92468F9F0007E397F /* RootTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB341F82468F9F0007E397F /* RootTabBarController.swift */; };
 		2FB342042468FFCC007E397F /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB342032468FFCC007E397F /* Navigator.swift */; };
 		2FB34207246901DA007E397F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2FB34205246901DA007E397F /* LaunchScreen.storyboard */; };
+		2FF5627C2475F0D000194144 /* LocationServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF5627B2475F0D000194144 /* LocationServices.swift */; };
+		2FF5627E2476035C00194144 /* LocationServicesObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF5627D2476035C00194144 /* LocationServicesObserver.swift */; };
 		49D0B0B42467BC6E007B3762 /* FightPandemicsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D0B0B32467BC6E007B3762 /* FightPandemicsUITests.swift */; };
 		7DEF116C7BC2A4F6BA56F4F0 /* Pods_FightPandemics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC14540D23239E4E26F554CF /* Pods_FightPandemics.framework */; };
 		C013ACDA246FF3E200F22BE7 /* OfferRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C013ACD9246FF3E200F22BE7 /* OfferRequest.swift */; };
@@ -178,6 +180,8 @@
 		2FB341F82468F9F0007E397F /* RootTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabBarController.swift; sourceTree = "<group>"; };
 		2FB342032468FFCC007E397F /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
 		2FB34206246901DA007E397F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		2FF5627B2475F0D000194144 /* LocationServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServices.swift; sourceTree = "<group>"; };
+		2FF5627D2476035C00194144 /* LocationServicesObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServicesObserver.swift; sourceTree = "<group>"; };
 		49D0B0B12467BC6E007B3762 /* FightPandemicsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FightPandemicsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		49D0B0B32467BC6E007B3762 /* FightPandemicsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FightPandemicsUITests.swift; sourceTree = "<group>"; };
 		49D0B0B52467BC6E007B3762 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -478,6 +482,7 @@
 				2FB341EA2468F841007E397F /* Extensions */,
 				DC807E67247027C700046D67 /* FileReader */,
 				2F426BA724736826007A4796 /* HTML */,
+				2FF5627A2475F0BB00194144 /* Location */,
 				2FB342022468FFC3007E397F /* Navigation */,
 				2F72CE452468785200750785 /* Networking */,
 				DC807E6C247027CF00046D67 /* SessionManager */,
@@ -528,6 +533,15 @@
 				2FB342032468FFCC007E397F /* Navigator.swift */,
 			);
 			path = Navigation;
+			sourceTree = "<group>";
+		};
+		2FF5627A2475F0BB00194144 /* Location */ = {
+			isa = PBXGroup;
+			children = (
+				2FF5627B2475F0D000194144 /* LocationServices.swift */,
+				2FF5627D2476035C00194144 /* LocationServicesObserver.swift */,
+			);
+			path = Location;
 			sourceTree = "<group>";
 		};
 		49D0B0B22467BC6E007B3762 /* FightPandemicsUITests */ = {
@@ -834,6 +848,7 @@
 				2F0B5168246E0DF200BE42BC /* CreatePostBody.swift in Sources */,
 				DC807E70247027CF00046D67 /* SessionManagerError.swift in Sources */,
 				2F042199246CE4B3005FB1D0 /* LogInViewController.swift in Sources */,
+				2FF5627C2475F0D000194144 /* LocationServices.swift in Sources */,
 				2F04210E246A1021005FB1D0 /* FeedPost.swift in Sources */,
 				2FB341EC2468F841007E397F /* UIColor+FightPandemics.swift in Sources */,
 				2F72CE562468789000750785 /* User.swift in Sources */,
@@ -856,6 +871,7 @@
 				2F0C3C652471DB2D0002B384 /* RootNavigationController.swift in Sources */,
 				2FB342042468FFCC007E397F /* Navigator.swift in Sources */,
 				2F0C3C44246F51BB0002B384 /* PostReactionButton.swift in Sources */,
+				2FF5627E2476035C00194144 /* LocationServicesObserver.swift in Sources */,
 				2F042190246CCD4A005FB1D0 /* ProfileViewController.swift in Sources */,
 				2F426BA024735B89007A4796 /* OpenSourceLicense.swift in Sources */,
 				2F0421A4246D04B9005FB1D0 /* AutoLogInFakeLaunchScreen.swift in Sources */,

--- a/FightPandemics/Features/Filters/FiltersModal.swift
+++ b/FightPandemics/Features/Filters/FiltersModal.swift
@@ -27,22 +27,51 @@
 import UIKit
 
 final class FiltersModal: UIViewController {
+    // MARK: - Properties
+
+    var locationServices: LocationServices!
     var navigator: Navigator!
+
+    private var locationServicesDeniedLabel = UILabel()
+
+    // MARK: - Init/Deinit
+
+    deinit {
+        locationServices.removeObserver(self)
+    }
+
+    // MARK: - Overrides
+
+    // MARK: View life-cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         setupUI()
+        locationServices.addObserver(self)
+        locationServices.requestPermission()
     }
 
+    // MARK: - Instance mtehods
+
     private func setupUI() {
-        let button = UIButton()
-        button.makeSubview(of: view)
+        locationServicesDeniedLabel.numberOfLines = 0
+        locationServicesDeniedLabel.textAlignment = .center
+        locationServicesDeniedLabel.makeSubview(of: view)
             .center()
-            .width(250)
-            .height(50)
-        button.backgroundColor = .systemBlue
-        button.setTitle("Request Location Permission", for: .normal)
-        button.setTitleColor(.white, for: .normal)
+            .leading(to: \.leadingAnchor, constant: 8)
+            .trailing(to: \.trailingAnchor, constant: -8)
+        locationServicesDeniedLabel.text = "LocationServicesDeniedCTA".localized
+        locationServicesDeniedLabel.isHidden = !locationServices.isPermissionDenied
+    }
+}
+
+// MARK: - Protocol conformance
+
+// MARK: LocationServicesObserver
+
+extension FiltersModal: LocationServicesObserver {
+    func locationServicesPermissionsDidChange() {
+        locationServicesDeniedLabel.isHidden = !locationServices.isPermissionDenied
     }
 }

--- a/FightPandemics/Info.plist
+++ b/FightPandemics/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>FightPandemics uses location to show hospitals and information near you</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/FightPandemics/Resources/en.lproj/Localizable.strings
+++ b/FightPandemics/Resources/en.lproj/Localizable.strings
@@ -62,3 +62,7 @@
 
 "OpenSourceCreditsTitle" = "Open Source Libraries";
 "LogOutCTA" = "Log Out";
+
+// MARK: Miscellaneous
+
+"LocationServicesDeniedCTA" = "Enable Location Services in Settings to search nearby";

--- a/FightPandemics/SceneDelegate.swift
+++ b/FightPandemics/SceneDelegate.swift
@@ -75,6 +75,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         navigator = Navigator(rootWindow: window,
                               api: api,
                               autoLoginFakeLaunchScreen: autoLoginFakeLaunchScreen,
+                              locationServices: LocationServices.shared,
                               sessionManager: sessionManager)
     }
 

--- a/FightPandemics/Utilities/Location/LocationServices.swift
+++ b/FightPandemics/Utilities/Location/LocationServices.swift
@@ -1,0 +1,106 @@
+//
+//  LocationServices.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/20/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import CoreLocation
+import Foundation
+
+final class LocationServices: NSObject {
+    // MARK: - Properties
+
+    static var shared = LocationServices()
+
+    /// Current Location permission status.
+    /// - Remark: Apple discourages relying on `CLLocationManager.authorizationStatus()` directly; instead `locationManager(didChangeAuthorization:)`
+    ///  is listened for and this value is kept up-to-date.
+    private(set) var permissionStatus: CLAuthorizationStatus = CLLocationManager.authorizationStatus() {
+        didSet {
+            notifyObservers()
+        }
+    }
+
+    var isPermissionAccepted: Bool {
+        return permissionStatus == .authorizedWhenInUse || permissionStatus == .authorizedAlways
+    }
+
+    var isPermissionDenied: Bool {
+        return permissionStatus == .denied || permissionStatus == .restricted
+    }
+
+    private let locationManger: CLLocationManager
+    private var observers = [ObjectIdentifier: Observation]()
+
+    // MARK: - Init/Deinit
+
+    init(locationManger: CLLocationManager = CLLocationManager()) {
+        self.locationManger = locationManger
+        super.init()
+        self.locationManger.delegate = self
+    }
+
+    // MARK: - Instance methods
+
+    func requestPermission() {
+        locationManger.requestWhenInUseAuthorization()
+    }
+}
+
+// MARK: - Observation
+
+extension LocationServices {
+    struct Observation {
+        weak var value: LocationServicesObserver?
+    }
+
+    func addObserver(_ observer: LocationServicesObserver) {
+        let id = ObjectIdentifier(observer)
+        observers[id] = Observation(value: observer)
+    }
+
+    func removeObserver(_ observer: LocationServicesObserver) {
+        let id = ObjectIdentifier(observer)
+        observers.removeValue(forKey: id)
+    }
+
+    private func notifyObservers() {
+        for (id, observer) in observers {
+            guard let observer = observer.value else {
+                observers.removeValue(forKey: id)
+                continue
+            }
+            observer.locationServicesPermissionsDidChange()
+        }
+    }
+}
+
+// MARK: - Protocol conformance
+
+// MARK: CLLocationManagerDelegate
+
+extension LocationServices: CLLocationManagerDelegate {
+    func locationManager(_: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        permissionStatus = status
+    }
+}

--- a/FightPandemics/Utilities/Location/LocationServicesObserver.swift
+++ b/FightPandemics/Utilities/Location/LocationServicesObserver.swift
@@ -1,0 +1,33 @@
+//
+//  LocationServicesObserver.swift
+//  FightPandemics
+//
+//  Created by Harlan Kellaway on 5/20/20.
+//
+//  Copyright (c) 2020 FightPandemics
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// Objects that want to be notified of significant events related to Location Services.
+protocol LocationServicesObserver: AnyObject {
+    /// Called when Location Services auth status changes.
+    func locationServicesPermissionsDidChange()
+}

--- a/FightPandemics/Utilities/Navigation/Navigator.swift
+++ b/FightPandemics/Utilities/Navigation/Navigator.swift
@@ -43,14 +43,19 @@ final class Navigator {
 
     private let api: API
     private let autoLoginFakeLaunchScreen: AutoLoginFakeLaunchScreen
+    private let locationServices: LocationServices
     private let sessionManager: SessionManager
 
     // MARK: - Init/Deinit
 
-    init(rootWindow: UIWindow?, api: API, autoLoginFakeLaunchScreen: AutoLoginFakeLaunchScreen, sessionManager: SessionManager) {
+    init(rootWindow: UIWindow?, api: API,
+         autoLoginFakeLaunchScreen: AutoLoginFakeLaunchScreen,
+         locationServices: LocationServices,
+         sessionManager: SessionManager) {
         self.rootWindow = rootWindow
         self.api = api
         self.autoLoginFakeLaunchScreen = autoLoginFakeLaunchScreen
+        self.locationServices = locationServices
         self.sessionManager = sessionManager
     }
 
@@ -152,6 +157,7 @@ final class Navigator {
 
     private func filtersModal() -> FiltersModal {
         let filtersModal = UIStoryboard(name: "Filters", bundle: nil).instantiateViewController(withIdentifier: "FiltersModal") as! FiltersModal
+        filtersModal.locationServices = locationServices
         filtersModal.navigator = self
         return filtersModal
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If this is your first time, please read our contributor guidelines: https://github.com/FightPandemics/FightPandemics-iOS/blob/develop/CONTRIBUTING.md
-->

**What this PR does**:

This PR creates a utility (`LocationServices`) that wraps all interaction with `CoreLocation`. It allows clients to request Locations permissions as well as register to observer that status changing.

### Checklist

- [x] Compiler warnings resolved
- [x] Linter warnings resolved
- [x] User-facing strings in Localizable.strings file
- [x] Unused code, print statements, and comments removed

**Which issue(s) this PR fixes**:

Resolves #93 

**Special notes for reviewers**:

See in action by selecting the Filters nav bar button and viewing the Filters modal

If you select `Deny`, you'll have to elect to `Erase All Content and Settings` from the Simulator to get back to a state where permissions are requestable again

**Additional comments**:

Observation pattern implementation from: https://www.swiftbysundell.com/articles/observers-in-swift-part-1/
